### PR TITLE
Add project reference configuration to Codex environment

### DIFF
--- a/.codex/enviroment.json
+++ b/.codex/enviroment.json
@@ -1,5 +1,17 @@
 {
   "language": "csharp",
   "framework": ".NET 8",
-  "projectType": "webapi"
+  "projectType": "webapi",
+  "projects": [
+    "src/TruyenVerse.Api",
+    "src/TruyenVerse.Application",
+    "src/TruyenVerse.Domain",
+    "src/TruyenVerse.Infrastructure"
+  ],
+  "entryProject": "src/TruyenVerse.Api",
+  "rules": {
+    "ensureProjectsAddedToSolution": true,
+    "ensureProjectReferences": true,
+    "respectArchitectureLayers": true
+  }
 }


### PR DESCRIPTION
## Summary
- configure Codex environment with project list and reference rules for TruyenVerse projects

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b42078bd088331b20159b31fee8c0c