### PR TITLE
Make user role nullable and add JWT authentication

### DIFF
--- a/src/TruyenVerse.Api/Controllers/StoriesController.cs
+++ b/src/TruyenVerse.Api/Controllers/StoriesController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using TruyenVerse.Application.Interfaces.Services;
 using TruyenVerse.Domain.Entities;
@@ -6,6 +7,7 @@ namespace TruyenVerse.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
+    [Authorize]
     public class StoriesController : ControllerBase
     {
         private readonly IStoryService _storyService;

--- a/src/TruyenVerse.Api/Controllers/UsersController.cs
+++ b/src/TruyenVerse.Api/Controllers/UsersController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using TruyenVerse.Application.Interfaces.Services;
 using TruyenVerse.Domain.Entities;
@@ -7,17 +8,21 @@ namespace TruyenVerse.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
+    [Authorize]
     public class UsersController : ControllerBase
     {
         private readonly IUserService _userService;
+        private readonly IJwtTokenService _tokenService;
 
-        public UsersController(IUserService userService)
+        public UsersController(IUserService userService, IJwtTokenService tokenService)
         {
             _userService = userService;
+            _tokenService = tokenService;
         }
 
         [HttpPost("login")]
-        public async Task<ActionResult<User>> Login(LoginRequest request)
+        [AllowAnonymous]
+        public async Task<ActionResult<string>> Login(LoginRequest request)
         {
             var user = await _userService.LoginAsync(request.Email, request.Password);
             if (user is null)
@@ -25,10 +30,12 @@ namespace TruyenVerse.Api.Controllers
                 return Unauthorized();
             }
 
-            return Ok(user);
+            var token = _tokenService.GenerateToken(user);
+            return Ok(token);
         }
 
         [HttpPost("register")]
+        [AllowAnonymous]
         public async Task<ActionResult<User>> Register(RegisterRequest request)
         {
             var user = await _userService.RegisterAsync(request.Email, request.Password, request.FullName);
@@ -36,6 +43,7 @@ namespace TruyenVerse.Api.Controllers
         }
 
         [HttpPost("forgot-password")]
+        [AllowAnonymous]
         public async Task<IActionResult> ForgotPassword(ForgotPasswordRequest request)
         {
             await _userService.ForgotPasswordAsync(request.Email);

--- a/src/TruyenVerse.Api/Program.cs
+++ b/src/TruyenVerse.Api/Program.cs
@@ -1,10 +1,33 @@
+using System.Text;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
 using TruyenVerse.Application;
 using TruyenVerse.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddApplication();
-builder.Services.AddInfrastructure();
+builder.Services.AddInfrastructure(builder.Configuration);
+
+var key = builder.Configuration["Jwt:Key"] ?? "supersecret";
+var keyBytes = Encoding.UTF8.GetBytes(key);
+
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+})
+.AddJwtBearer(options =>
+{
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = false,
+        ValidateAudience = false,
+        ValidateIssuerSigningKey = true,
+        IssuerSigningKey = new SymmetricSecurityKey(keyBytes)
+    };
+});
+builder.Services.AddAuthorization();
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
@@ -19,6 +42,9 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapControllers();
 

--- a/src/TruyenVerse.Api/TruyenVerse.Api.csproj
+++ b/src/TruyenVerse.Api/TruyenVerse.Api.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/TruyenVerse.Application/Interfaces/Services/IJwtTokenService.cs
+++ b/src/TruyenVerse.Application/Interfaces/Services/IJwtTokenService.cs
@@ -1,0 +1,9 @@
+using TruyenVerse.Domain.Entities;
+
+namespace TruyenVerse.Application.Interfaces.Services
+{
+    public interface IJwtTokenService
+    {
+        string GenerateToken(User user);
+    }
+}

--- a/src/TruyenVerse.Application/Services/UserService.cs
+++ b/src/TruyenVerse.Application/Services/UserService.cs
@@ -47,8 +47,7 @@ namespace TruyenVerse.Application.Services
             {
                 Email = email,
                 Password = password,
-                FullName = fullName,
-                Role = UserRole.Admin
+                FullName = fullName
             };
 
             await _repository.AddAsync(user);

--- a/src/TruyenVerse.Domain/Entities/User.cs
+++ b/src/TruyenVerse.Domain/Entities/User.cs
@@ -10,6 +10,6 @@ namespace TruyenVerse.Domain.Entities
         public Gender Gender { get; set; } = Gender.Unknown;
         public string Address { get; set; } = string.Empty;
         public string Introduction { get; set; } = string.Empty;
-        public UserRole Role { get; set; } = UserRole.Admin;
+        public UserRole? Role { get; set; }
     }
 }

--- a/src/TruyenVerse.Infrastructure/DependencyInjection.cs
+++ b/src/TruyenVerse.Infrastructure/DependencyInjection.cs
@@ -1,15 +1,20 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using TruyenVerse.Application.Interfaces.Repositories;
+using TruyenVerse.Application.Interfaces.Services;
 using TruyenVerse.Infrastructure.Persistence;
+using TruyenVerse.Infrastructure.Services;
 
 namespace TruyenVerse.Infrastructure
 {
     public static class DependencyInjection
     {
-        public static IServiceCollection AddInfrastructure(this IServiceCollection services)
+        public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
         {
             services.AddSingleton<IUserRepository, InMemoryUserRepository>();
             services.AddSingleton<IStoryRepository, InMemoryStoryRepository>();
+            var secret = configuration["Jwt:Key"] ?? "supersecret";
+            services.AddSingleton<IJwtTokenService>(new JwtTokenService(secret));
             return services;
         }
     }

--- a/src/TruyenVerse.Infrastructure/Services/JwtTokenService.cs
+++ b/src/TruyenVerse.Infrastructure/Services/JwtTokenService.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+using TruyenVerse.Application.Interfaces.Services;
+using TruyenVerse.Domain.Entities;
+
+namespace TruyenVerse.Infrastructure.Services
+{
+    public class JwtTokenService : IJwtTokenService
+    {
+        private readonly string _secret;
+
+        public JwtTokenService(string secret)
+        {
+            _secret = secret;
+        }
+
+        public string GenerateToken(User user)
+        {
+            var tokenHandler = new JwtSecurityTokenHandler();
+            var key = Encoding.UTF8.GetBytes(_secret);
+            var claims = new List<Claim>
+            {
+                new(ClaimTypes.NameIdentifier, user.Id.ToString()),
+                new(ClaimTypes.Email, user.Email)
+            };
+            if (user.Role.HasValue)
+            {
+                claims.Add(new Claim(ClaimTypes.Role, user.Role.Value.ToString()));
+            }
+
+            var tokenDescriptor = new SecurityTokenDescriptor
+            {
+                Subject = new ClaimsIdentity(claims),
+                Expires = DateTime.UtcNow.AddHours(1),
+                SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
+            };
+
+            var token = tokenHandler.CreateToken(tokenDescriptor);
+            return tokenHandler.WriteToken(token);
+        }
+    }
+}

--- a/src/TruyenVerse.Infrastructure/TruyenVerse.Infrastructure.csproj
+++ b/src/TruyenVerse.Infrastructure/TruyenVerse.Infrastructure.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\\TruyenVerse.Domain\\TruyenVerse.Domain.csproj" />


### PR DESCRIPTION
## Summary
- Allow users to have no role by default and remove hardcoded admin assignment
- Implement JWT token generation and wire up authentication/authorization
- Protect story endpoints and user operations with `[Authorize]`

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b423d6b2c083319b826890ebd0776e