### PR TITLE
Add appsettings configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -236,7 +236,6 @@ artifacts/
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudio,dotnetcore
 
-# Ignore environment configuration files
-src/TruyenVerse.Api/appsettings.json
+# Ignore environment-specific configuration files
 src/TruyenVerse.Api/appsettings.Development.json
 

--- a/src/TruyenVerse.Api/appsettings.json
+++ b/src/TruyenVerse.Api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary
- add default API appsettings with logging and host configuration
- ignore only the development appsettings file

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b45c1e7cb48331812c9a7bd20f9d9c