### PR TITLE
Add user relation to stories and chapter navigation

### DIFF
--- a/src/TruyenVerse.Api/Controllers/StoriesController.cs
+++ b/src/TruyenVerse.Api/Controllers/StoriesController.cs
@@ -20,7 +20,7 @@ namespace TruyenVerse.Api.Controllers
         [HttpPost]
         public async Task<ActionResult<Story>> CreateStory(CreateStoryRequest request)
         {
-            var story = await _storyService.CreateStoryAsync(request.Title, request.Description);
+            var story = await _storyService.CreateStoryAsync(request.UserId, request.Title, request.Description);
             return Ok(story);
         }
 
@@ -60,7 +60,7 @@ namespace TruyenVerse.Api.Controllers
         }
     }
 
-    public record CreateStoryRequest(string Title, string Description);
+    public record CreateStoryRequest(Guid UserId, string Title, string Description);
     public record UpdateStoryRequest(string Title, string Description);
     public record AddChapterRequest(string Title, string Content);
     public record UpdateChapterRequest(string Title, string Content);

--- a/src/TruyenVerse.Application/Interfaces/Services/IStoryService.cs
+++ b/src/TruyenVerse.Application/Interfaces/Services/IStoryService.cs
@@ -4,7 +4,7 @@ namespace TruyenVerse.Application.Interfaces.Services
 {
     public interface IStoryService
     {
-        Task<Story> CreateStoryAsync(string title, string description);
+        Task<Story> CreateStoryAsync(Guid userId, string title, string description);
         Task UpdateStoryAsync(Guid storyId, string title, string description);
         Task DeleteStoryAsync(Guid storyId);
         Task<Chapter> AddChapterAsync(Guid storyId, string title, string content);

--- a/src/TruyenVerse.Application/Services/StoryService.cs
+++ b/src/TruyenVerse.Application/Services/StoryService.cs
@@ -13,7 +13,7 @@ namespace TruyenVerse.Application.Services
             _repository = repository;
         }
 
-        public async Task<Story> CreateStoryAsync(string title, string description)
+        public async Task<Story> CreateStoryAsync(Guid userId, string title, string description)
         {
             if (string.IsNullOrWhiteSpace(title))
             {
@@ -22,6 +22,7 @@ namespace TruyenVerse.Application.Services
 
             var story = new Story
             {
+                UserId = userId,
                 Title = title,
                 Description = description
             };

--- a/src/TruyenVerse.Domain/Entities/Chapter.cs
+++ b/src/TruyenVerse.Domain/Entities/Chapter.cs
@@ -3,6 +3,7 @@ namespace TruyenVerse.Domain.Entities
     public class Chapter : BaseEntity
     {
         public Guid StoryId { get; set; }
+        public Story? Story { get; set; }
         public string Title { get; set; } = string.Empty;
         public string Content { get; set; } = string.Empty;
     }

--- a/src/TruyenVerse.Domain/Entities/Story.cs
+++ b/src/TruyenVerse.Domain/Entities/Story.cs
@@ -4,6 +4,8 @@ namespace TruyenVerse.Domain.Entities
 {
     public class Story : BaseEntity
     {
+        public Guid UserId { get; set; }
+        public User? User { get; set; }
         public string Title { get; set; } = string.Empty;
         public string Description { get; set; } = string.Empty;
         public List<Chapter> Chapters { get; set; } = new();

--- a/src/TruyenVerse.Domain/Entities/User.cs
+++ b/src/TruyenVerse.Domain/Entities/User.cs
@@ -11,5 +11,6 @@ namespace TruyenVerse.Domain.Entities
         public string Address { get; set; } = string.Empty;
         public string Introduction { get; set; } = string.Empty;
         public UserRole? Role { get; set; }
+        public List<Story>? Stories { get; set; }
     }
 }

--- a/src/TruyenVerse.Infrastructure/Persistence/EfStoryRepository.cs
+++ b/src/TruyenVerse.Infrastructure/Persistence/EfStoryRepository.cs
@@ -31,12 +31,18 @@ namespace TruyenVerse.Infrastructure.Persistence
 
         public async Task<IEnumerable<Story>> GetAllAsync()
         {
-            return await _context.Stories.Include(s => s.Chapters).ToListAsync();
+            return await _context.Stories
+                .Include(s => s.User)
+                .Include(s => s.Chapters)
+                .ToListAsync();
         }
 
         public async Task<Story?> GetByIdAsync(Guid id)
         {
-            return await _context.Stories.Include(s => s.Chapters).FirstOrDefaultAsync(s => s.Id == id);
+            return await _context.Stories
+                .Include(s => s.User)
+                .Include(s => s.Chapters)
+                .FirstOrDefaultAsync(s => s.Id == id);
         }
 
         public async Task UpdateAsync(Story story)

--- a/src/TruyenVerse.Infrastructure/Persistence/TruyenVerseDbContext.cs
+++ b/src/TruyenVerse.Infrastructure/Persistence/TruyenVerseDbContext.cs
@@ -16,11 +16,6 @@ namespace TruyenVerse.Infrastructure.Persistence
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
-
-            modelBuilder.Entity<Story>()
-                .HasMany(s => s.Chapters)
-                .WithOne()
-                .HasForeignKey(c => c.StoryId);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Link chapters to their parent story with navigation property
- Associate stories with users and expose user story collections
- Remove explicit model configuration and include users in EF story queries
- Allow users to have a nullable story collection

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4664ab0c0833199c9e4a379ef4b76