### PR TITLE
Add StoryFollow entity

### DIFF
--- a/src/TruyenVerse.Domain/Entities/Story.cs
+++ b/src/TruyenVerse.Domain/Entities/Story.cs
@@ -9,5 +9,6 @@ namespace TruyenVerse.Domain.Entities
         public string Title { get; set; } = string.Empty;
         public string Description { get; set; } = string.Empty;
         public List<Chapter> Chapters { get; set; } = new();
+        public List<StoryFollow>? Followers { get; set; }
     }
 }

--- a/src/TruyenVerse.Domain/Entities/StoryFollow.cs
+++ b/src/TruyenVerse.Domain/Entities/StoryFollow.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace TruyenVerse.Domain.Entities
+{
+    public class StoryFollow : BaseEntity
+    {
+        public Guid UserId { get; set; }
+        public User? User { get; set; }
+        public Guid StoryId { get; set; }
+        public Story? Story { get; set; }
+    }
+}

--- a/src/TruyenVerse.Domain/Entities/User.cs
+++ b/src/TruyenVerse.Domain/Entities/User.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using TruyenVerse.Domain.Enums;
 
 namespace TruyenVerse.Domain.Entities
@@ -12,5 +13,6 @@ namespace TruyenVerse.Domain.Entities
         public string Introduction { get; set; } = string.Empty;
         public UserRole? Role { get; set; }
         public List<Story>? Stories { get; set; }
+        public List<StoryFollow>? FollowedStories { get; set; }
     }
 }

--- a/src/TruyenVerse.Infrastructure/Persistence/TruyenVerseDbContext.cs
+++ b/src/TruyenVerse.Infrastructure/Persistence/TruyenVerseDbContext.cs
@@ -12,6 +12,7 @@ namespace TruyenVerse.Infrastructure.Persistence
         public DbSet<User> Users => Set<User>();
         public DbSet<Story> Stories => Set<Story>();
         public DbSet<Chapter> Chapters => Set<Chapter>();
+        public DbSet<StoryFollow> StoryFollows => Set<StoryFollow>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {


### PR DESCRIPTION
## Summary
- track user story follows with new StoryFollow entity
- link stories and users with follower collections
- add StoryFollows DbSet to EF Core context
- default follow collections to null for users and stories

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b872ec5fd4833198506a88663bddbf