### PR TITLE
feat: add base repository for common CRUD operations

### DIFF
--- a/src/TruyenVerse.Infrastructure/Persistence/EfRepository.cs
+++ b/src/TruyenVerse.Infrastructure/Persistence/EfRepository.cs
@@ -1,0 +1,98 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using TruyenVerse.Domain.Entities;
+
+namespace TruyenVerse.Infrastructure.Persistence;
+
+public abstract class EfRepository<TEntity> where TEntity : BaseEntity
+{
+    protected readonly TruyenVerseDbContext Context;
+    protected DbSet<TEntity> Entities => Context.Set<TEntity>();
+
+    protected EfRepository(TruyenVerseDbContext context)
+    {
+        Context = context;
+    }
+
+    public virtual async Task<TEntity?> GetByIdAsync(Guid id) =>
+        await Entities.FindAsync(id);
+
+    public virtual async Task<TEntity?> GetAsync(Expression<Func<TEntity, bool>> predicate) =>
+        await Entities.FirstOrDefaultAsync(predicate);
+
+    public virtual async Task<TEntity?> GetAsNoTrackingAsync(Expression<Func<TEntity, bool>> predicate) =>
+        await Entities.AsNoTracking().FirstOrDefaultAsync(predicate);
+
+    public virtual async Task<IEnumerable<TEntity>> GetAllAsync() =>
+        await Entities.ToListAsync();
+
+    public virtual async Task AddAsync(TEntity entity, bool autoSave = true)
+    {
+        Entities.Add(entity);
+        if (autoSave)
+        {
+            await Context.SaveChangesAsync();
+        }
+    }
+
+    public virtual async Task AddRangeAsync(IEnumerable<TEntity> entities, bool autoSave = true)
+    {
+        Entities.AddRange(entities);
+        if (autoSave)
+        {
+            await Context.SaveChangesAsync();
+        }
+    }
+
+    public virtual async Task UpdateAsync(TEntity entity, bool autoSave = true)
+    {
+        Entities.Update(entity);
+        if (autoSave)
+        {
+            await Context.SaveChangesAsync();
+        }
+    }
+
+    public virtual async Task UpdateRangeAsync(IEnumerable<TEntity> entities, bool autoSave = true)
+    {
+        Entities.UpdateRange(entities);
+        if (autoSave)
+        {
+            await Context.SaveChangesAsync();
+        }
+    }
+
+    public virtual async Task DeleteAsync(Guid id, bool autoSave = true)
+    {
+        var entity = await GetByIdAsync(id);
+        if (entity is null)
+        {
+            return;
+        }
+
+        Entities.Remove(entity);
+        if (autoSave)
+        {
+            await Context.SaveChangesAsync();
+        }
+    }
+
+    public virtual async Task DeleteAsync(TEntity entity, bool autoSave = true)
+    {
+        Entities.Remove(entity);
+        if (autoSave)
+        {
+            await Context.SaveChangesAsync();
+        }
+    }
+
+    public virtual async Task DeleteRangeAsync(IEnumerable<TEntity> entities, bool autoSave = true)
+    {
+        Entities.RemoveRange(entities);
+        if (autoSave)
+        {
+            await Context.SaveChangesAsync();
+        }
+    }
+}
+

--- a/src/TruyenVerse.Infrastructure/Persistence/EfStoryRepository.cs
+++ b/src/TruyenVerse.Infrastructure/Persistence/EfStoryRepository.cs
@@ -2,62 +2,24 @@ using Microsoft.EntityFrameworkCore;
 using TruyenVerse.Application.Interfaces.Repositories;
 using TruyenVerse.Domain.Entities;
 
-namespace TruyenVerse.Infrastructure.Persistence
+namespace TruyenVerse.Infrastructure.Persistence;
+
+public class EfStoryRepository : EfRepository<Story>, IStoryRepository
 {
-    public class EfStoryRepository : IStoryRepository
+    public EfStoryRepository(TruyenVerseDbContext context) : base(context)
     {
-        private readonly TruyenVerseDbContext _context;
-
-        public EfStoryRepository(TruyenVerseDbContext context)
-        {
-            _context = context;
-        }
-
-        public async Task AddAsync(Story story, bool autoSave = true)
-        {
-            _context.Stories.Add(story);
-            if (autoSave)
-            {
-                await _context.SaveChangesAsync();
-            }
-        }
-
-        public async Task DeleteAsync(Guid id, bool autoSave = true)
-        {
-            var story = await _context.Stories.FindAsync(id);
-            if (story != null)
-            {
-                _context.Stories.Remove(story);
-                if (autoSave)
-                {
-                    await _context.SaveChangesAsync();
-                }
-            }
-        }
-
-        public async Task<IEnumerable<Story>> GetAllAsync()
-        {
-            return await _context.Stories
-                .Include(s => s.User)
-                .Include(s => s.Chapters)
-                .ToListAsync();
-        }
-
-        public async Task<Story?> GetByIdAsync(Guid id)
-        {
-            return await _context.Stories
-                .Include(s => s.User)
-                .Include(s => s.Chapters)
-                .FirstOrDefaultAsync(s => s.Id == id);
-        }
-
-        public async Task UpdateAsync(Story story, bool autoSave = true)
-        {
-            _context.Stories.Update(story);
-            if (autoSave)
-            {
-                await _context.SaveChangesAsync();
-            }
-        }
     }
+
+    public override async Task<IEnumerable<Story>> GetAllAsync() =>
+        await Entities
+            .Include(s => s.User)
+            .Include(s => s.Chapters)
+            .ToListAsync();
+
+    public override async Task<Story?> GetByIdAsync(Guid id) =>
+        await Entities
+            .Include(s => s.User)
+            .Include(s => s.Chapters)
+            .FirstOrDefaultAsync(s => s.Id == id);
 }
+

--- a/src/TruyenVerse.Infrastructure/Persistence/EfUserRepository.cs
+++ b/src/TruyenVerse.Infrastructure/Persistence/EfUserRepository.cs
@@ -2,48 +2,15 @@ using Microsoft.EntityFrameworkCore;
 using TruyenVerse.Application.Interfaces.Repositories;
 using TruyenVerse.Domain.Entities;
 
-namespace TruyenVerse.Infrastructure.Persistence
+namespace TruyenVerse.Infrastructure.Persistence;
+
+public class EfUserRepository : EfRepository<User>, IUserRepository
 {
-    public class EfUserRepository : IUserRepository
+    public EfUserRepository(TruyenVerseDbContext context) : base(context)
     {
-        private readonly TruyenVerseDbContext _context;
-
-        public EfUserRepository(TruyenVerseDbContext context)
-        {
-            _context = context;
-        }
-
-        public async Task AddAsync(User user, bool autoSave = true)
-        {
-            _context.Users.Add(user);
-            if (autoSave)
-            {
-                await _context.SaveChangesAsync();
-            }
-        }
-
-        public async Task<IEnumerable<User>> GetAllAsync()
-        {
-            return await _context.Users.ToListAsync();
-        }
-
-        public async Task<User?> GetByEmailAsync(string email)
-        {
-            return await _context.Users.FirstOrDefaultAsync(u => u.Email == email);
-        }
-
-        public async Task<User?> GetByIdAsync(Guid id)
-        {
-            return await _context.Users.FindAsync(id);
-        }
-
-        public async Task UpdateAsync(User user, bool autoSave = true)
-        {
-            _context.Users.Update(user);
-            if (autoSave)
-            {
-                await _context.SaveChangesAsync();
-            }
-        }
     }
+
+    public Task<User?> GetByEmailAsync(string email) =>
+        Entities.FirstOrDefaultAsync(u => u.Email == email);
 }
+


### PR DESCRIPTION
## Summary
- introduce generic `EfRepository` with common CRUD helpers and optional auto-save
- refactor `EfUserRepository` to inherit from the new base repository
- refactor `EfStoryRepository` to reuse base logic and override retrieval with includes

## Testing
- `dotnet build` *(fails: dotnet not installed)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b87c03a2208331ab80c635c297ee8d