### PR TITLE
Add claims extension for user ID retrieval

### DIFF
--- a/Hackathon/Hackathon/Extensions/ClaimsPrincipalExtensions.cs
+++ b/Hackathon/Hackathon/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,20 @@
+namespace Hackathon.Extensions;
+
+using System.Security.Claims;
+
+public static class ClaimsPrincipalExtensions
+{
+    public static long? GetUserId(this ClaimsPrincipal user)
+    {
+        if (user.Identity?.IsAuthenticated != true)
+        {
+            return null;
+        }
+
+        var claim = user.FindFirst(ClaimTypes.NameIdentifier);
+        return claim != null && long.TryParse(claim.Value, out var userId)
+            ? userId
+            : null;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add ClaimsPrincipal extension to parse user ID when authenticated

## Testing
- `dotnet build Hackathon/Hackathon.sln` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1ba072d8833188804de5904132c3