### PR TITLE
Add ISO document upload service and repository

### DIFF
--- a/Hackathon/Hackathon/Controllers/IsoDocumentsController.cs
+++ b/Hackathon/Hackathon/Controllers/IsoDocumentsController.cs
@@ -1,0 +1,43 @@
+using Hackathon.Extensions;
+using Hackathon.Models.Dtos;
+using Hackathon.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System;
+
+namespace Hackathon.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize(Policy = "AdminOrAnalyst")]
+public class IsoDocumentsController : ControllerBase
+{
+    private readonly IIsoDocumentService _service;
+
+    public IsoDocumentsController(IIsoDocumentService service)
+    {
+        _service = service;
+    }
+
+    [HttpPost]
+    [RequestSizeLimit(1L * 1024 * 1024 * 1024)]
+    public async Task<IActionResult> Upload([FromForm] UploadIsoDocumentRequest request)
+    {
+        var userId = User.GetUserId();
+        if (userId == null)
+        {
+            return Unauthorized();
+        }
+
+        try
+        {
+            var document = await _service.UploadAsync(request, userId.Value);
+            return Ok(new { document.Id, document.Version });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+    }
+}
+

--- a/Hackathon/Hackathon/Extensions/ClaimsPrincipalExtensions.cs
+++ b/Hackathon/Hackathon/Extensions/ClaimsPrincipalExtensions.cs
@@ -16,5 +16,15 @@ public static class ClaimsPrincipalExtensions
             ? userId
             : null;
     }
+
+    public static string? GetUserRole(this ClaimsPrincipal user)
+    {
+        if (user.Identity?.IsAuthenticated != true)
+        {
+            return null;
+        }
+
+        return user.FindFirst(ClaimTypes.Role)?.Value;
+    }
 }
 

--- a/Hackathon/Hackathon/Models/Dtos/UploadIsoDocumentRequest.cs
+++ b/Hackathon/Hackathon/Models/Dtos/UploadIsoDocumentRequest.cs
@@ -1,0 +1,11 @@
+namespace Hackathon.Models.Dtos;
+
+using Microsoft.AspNetCore.Http;
+
+public class UploadIsoDocumentRequest
+{
+    public int Year { get; set; }
+    public string? Notes { get; set; }
+    public IFormFileCollection Files { get; set; } = default!;
+}
+

--- a/Hackathon/Hackathon/Program.cs
+++ b/Hackathon/Hackathon/Program.cs
@@ -18,8 +18,10 @@ builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString)));
 
 builder.Services.AddScoped<IUserRepository, UserRepository>();
+builder.Services.AddScoped<IIsoDocumentRepository, IsoDocumentRepository>();
 builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
 builder.Services.AddScoped<IAuthService, AuthService>();
+builder.Services.AddScoped<IIsoDocumentService, IsoDocumentService>();
 builder.Services.AddMinio(config =>
 {
     config.WithEndpoint(builder.Configuration["Minio:Endpoint"]!)
@@ -47,6 +49,12 @@ builder.Services.AddAuthentication(options =>
         ValidAudience = jwtSection["Audience"],
         IssuerSigningKey = new SymmetricSecurityKey(key)
     };
+});
+
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("AdminOrAnalyst", policy =>
+        policy.RequireRole("admin", "analyst"));
 });
 
 var app = builder.Build();

--- a/Hackathon/Hackathon/Repositories/IIsoDocumentRepository.cs
+++ b/Hackathon/Hackathon/Repositories/IIsoDocumentRepository.cs
@@ -1,0 +1,9 @@
+namespace Hackathon.Repositories;
+
+using Hackathon.Models;
+
+public interface IIsoDocumentRepository
+{
+    Task<int> CountByYearAsync(int year);
+    Task AddAsync(IsoDocument document);
+}

--- a/Hackathon/Hackathon/Repositories/IsoDocumentRepository.cs
+++ b/Hackathon/Hackathon/Repositories/IsoDocumentRepository.cs
@@ -1,0 +1,14 @@
+namespace Hackathon.Repositories;
+
+using Hackathon.Models;
+using Hackathon.UnitOfWork;
+using Microsoft.EntityFrameworkCore;
+
+public class IsoDocumentRepository(AppDbContext context) : IIsoDocumentRepository
+{
+    public async Task<int> CountByYearAsync(int year) =>
+        await context.IsoDocuments.CountAsync(d => d.Year == year);
+
+    public async Task AddAsync(IsoDocument document) =>
+        await context.IsoDocuments.AddAsync(document);
+}

--- a/Hackathon/Hackathon/Services/IIsoDocumentService.cs
+++ b/Hackathon/Hackathon/Services/IIsoDocumentService.cs
@@ -1,0 +1,9 @@
+namespace Hackathon.Services;
+
+using Hackathon.Models;
+using Hackathon.Models.Dtos;
+
+public interface IIsoDocumentService
+{
+    Task<IsoDocument> UploadAsync(UploadIsoDocumentRequest request, long uploadedBy);
+}

--- a/Hackathon/Hackathon/Services/IsoDocumentService.cs
+++ b/Hackathon/Hackathon/Services/IsoDocumentService.cs
@@ -1,0 +1,56 @@
+namespace Hackathon.Services;
+
+using Hackathon.Models;
+using Hackathon.Models.Dtos;
+using Hackathon.UnitOfWork;
+using System;
+using System.Linq;
+
+public class IsoDocumentService(IUnitOfWork unitOfWork, IFileService fileService) : IIsoDocumentService
+{
+    private readonly IUnitOfWork _unitOfWork = unitOfWork;
+    private readonly IFileService _fileService = fileService;
+    private const long MaxRequestSize = 1L * 1024 * 1024 * 1024; // 1GB
+
+    public async Task<IsoDocument> UploadAsync(UploadIsoDocumentRequest request, long uploadedBy)
+    {
+        if (request.Files.Sum(f => f.Length) > MaxRequestSize)
+        {
+            throw new InvalidOperationException("Request size cannot exceed 1GB.");
+        }
+
+        foreach (var file in request.Files)
+        {
+            if (file.ContentType.StartsWith("video/", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Video files are not allowed.");
+            }
+        }
+
+        var count = await _unitOfWork.IsoDocuments.CountByYearAsync(request.Year);
+        var version = $"ISO_{request.Year}_v{count + 1}";
+
+        var document = new IsoDocument
+        {
+            Year = request.Year,
+            Notes = request.Notes,
+            Version = version,
+            UploadedBy = uploadedBy
+        };
+
+        foreach (var file in request.Files)
+        {
+            var path = await _fileService.UploadFileAsync(file);
+            document.Files.Add(new IsoFile
+            {
+                FilePath = path,
+                FileType = file.ContentType
+            });
+        }
+
+        await _unitOfWork.IsoDocuments.AddAsync(document);
+        await _unitOfWork.SaveChangesAsync();
+
+        return document;
+    }
+}

--- a/Hackathon/Hackathon/UnitOfWork/IUnitOfWork.cs
+++ b/Hackathon/Hackathon/UnitOfWork/IUnitOfWork.cs
@@ -5,6 +5,7 @@ using Hackathon.Repositories;
 public interface IUnitOfWork
 {
     IUserRepository Users { get; }
+    IIsoDocumentRepository IsoDocuments { get; }
     Task<int> SaveChangesAsync();
 }
 

--- a/Hackathon/Hackathon/UnitOfWork/UnitOfWork.cs
+++ b/Hackathon/Hackathon/UnitOfWork/UnitOfWork.cs
@@ -2,9 +2,10 @@ namespace Hackathon.UnitOfWork;
 
 using Hackathon.Repositories;
 
-public class UnitOfWork(AppDbContext context, IUserRepository users) : IUnitOfWork
+public class UnitOfWork(AppDbContext context, IUserRepository users, IIsoDocumentRepository isoDocuments) : IUnitOfWork
 {
     public IUserRepository Users { get; } = users;
+    public IIsoDocumentRepository IsoDocuments { get; } = isoDocuments;
 
     public async Task<int> SaveChangesAsync() => await context.SaveChangesAsync();
 }


### PR DESCRIPTION
## Summary
- accept `IFormFileCollection` in `UploadIsoDocumentRequest`
- move ISO document upload logic to `IsoDocumentService` with 1GB limit, video filter, and versioning
- add `IIsoDocumentRepository` and wire through `UnitOfWork` and DI

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1f92e4c083319a38d6d9c2c9f459