### PR TITLE
Add approved applications CRUD and ISO document lookup

### DIFF
--- a/Hackathon/Hackathon/Controllers/ApprovedApplicationsController.cs
+++ b/Hackathon/Hackathon/Controllers/ApprovedApplicationsController.cs
@@ -1,0 +1,67 @@
+using Hackathon.Models.Dtos;
+using Hackathon.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Hackathon.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize(Policy = "AdminOrAnalyst")]
+public class ApprovedApplicationsController(IApprovedApplicationService service) : ControllerBase
+{
+    [HttpGet]
+    public async Task<IActionResult> GetAll()
+    {
+        var apps = await service.GetAllAsync();
+        return Ok(apps);
+    }
+
+    [HttpGet("iso-document/{isoDocumentId:long}")]
+    public async Task<IActionResult> GetByIsoDocument(long isoDocumentId)
+    {
+        var apps = await service.GetByIsoDocumentIdAsync(isoDocumentId);
+        return Ok(apps);
+    }
+
+    [HttpGet("{id:long}")]
+    public async Task<IActionResult> Get(long id)
+    {
+        var app = await service.GetByIdAsync(id);
+        if (app == null)
+        {
+            return NotFound();
+        }
+        return Ok(app);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create(ApprovedApplicationRequest request)
+    {
+        var app = await service.CreateAsync(request);
+        return CreatedAtAction(nameof(Get), new { id = app.Id }, app);
+    }
+
+    [HttpPut("{id:long}")]
+    public async Task<IActionResult> Update(long id, ApprovedApplicationRequest request)
+    {
+        var success = await service.UpdateAsync(id, request);
+        if (!success)
+        {
+            return NotFound();
+        }
+        return NoContent();
+    }
+
+    [HttpDelete("{id:long}")]
+    public async Task<IActionResult> Delete(long id)
+    {
+        var success = await service.DeleteAsync(id);
+        if (!success)
+        {
+            return NotFound();
+        }
+        return NoContent();
+    }
+}
+

--- a/Hackathon/Hackathon/Controllers/IsoDocumentsController.cs
+++ b/Hackathon/Hackathon/Controllers/IsoDocumentsController.cs
@@ -19,6 +19,13 @@ public class IsoDocumentsController : ControllerBase
         _service = service;
     }
 
+    [HttpGet("year/{year:int}")]
+    public async Task<IActionResult> GetByYear(int year)
+    {
+        var documents = await _service.GetByYearAsync(year);
+        return Ok(documents);
+    }
+
     [HttpPost]
     [RequestSizeLimit(1L * 1024 * 1024 * 1024)]
     public async Task<IActionResult> Upload([FromForm] UploadIsoDocumentRequest request)

--- a/Hackathon/Hackathon/Models/Dtos/ApprovedApplicationRequest.cs
+++ b/Hackathon/Hackathon/Models/Dtos/ApprovedApplicationRequest.cs
@@ -1,0 +1,11 @@
+namespace Hackathon.Models.Dtos;
+
+public class ApprovedApplicationRequest
+{
+    public long IsoDocumentId { get; set; }
+    public required string AppName { get; set; }
+    public string? AppVersion { get; set; }
+    public string? Vendor { get; set; }
+    public string? Category { get; set; }
+}
+

--- a/Hackathon/Hackathon/Program.cs
+++ b/Hackathon/Hackathon/Program.cs
@@ -19,9 +19,11 @@ builder.Services.AddDbContext<AppDbContext>(options =>
 
 builder.Services.AddScoped<IUserRepository, UserRepository>();
 builder.Services.AddScoped<IIsoDocumentRepository, IsoDocumentRepository>();
+builder.Services.AddScoped<IApprovedApplicationRepository, ApprovedApplicationRepository>();
 builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
 builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<IIsoDocumentService, IsoDocumentService>();
+builder.Services.AddScoped<IApprovedApplicationService, ApprovedApplicationService>();
 builder.Services.AddMinio(config =>
 {
     config.WithEndpoint(builder.Configuration["Minio:Endpoint"]!)

--- a/Hackathon/Hackathon/Repositories/ApprovedApplicationRepository.cs
+++ b/Hackathon/Hackathon/Repositories/ApprovedApplicationRepository.cs
@@ -1,0 +1,31 @@
+namespace Hackathon.Repositories;
+
+using Hackathon.Models;
+using Hackathon.UnitOfWork;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
+
+public class ApprovedApplicationRepository(AppDbContext context) : IApprovedApplicationRepository
+{
+    public async Task<IEnumerable<ApprovedApplication>> GetAllAsync() =>
+        await context.ApprovedApplications.ToListAsync();
+
+    public async Task<ApprovedApplication?> GetByIdAsync(long id) =>
+        await context.ApprovedApplications.FindAsync(id);
+
+    public async Task<IEnumerable<ApprovedApplication>> GetByIsoDocumentIdAsync(long isoDocumentId) =>
+        await context.ApprovedApplications
+            .Where(a => a.IsoDocumentId == isoDocumentId)
+            .ToListAsync();
+
+    public async Task AddAsync(ApprovedApplication application) =>
+        await context.ApprovedApplications.AddAsync(application);
+
+    public void Update(ApprovedApplication application) =>
+        context.ApprovedApplications.Update(application);
+
+    public void Remove(ApprovedApplication application) =>
+        context.ApprovedApplications.Remove(application);
+}
+

--- a/Hackathon/Hackathon/Repositories/IApprovedApplicationRepository.cs
+++ b/Hackathon/Hackathon/Repositories/IApprovedApplicationRepository.cs
@@ -1,0 +1,15 @@
+namespace Hackathon.Repositories;
+
+using Hackathon.Models;
+using System.Collections.Generic;
+
+public interface IApprovedApplicationRepository
+{
+    Task<IEnumerable<ApprovedApplication>> GetAllAsync();
+    Task<ApprovedApplication?> GetByIdAsync(long id);
+    Task<IEnumerable<ApprovedApplication>> GetByIsoDocumentIdAsync(long isoDocumentId);
+    Task AddAsync(ApprovedApplication application);
+    void Update(ApprovedApplication application);
+    void Remove(ApprovedApplication application);
+}
+

--- a/Hackathon/Hackathon/Repositories/IIsoDocumentRepository.cs
+++ b/Hackathon/Hackathon/Repositories/IIsoDocumentRepository.cs
@@ -1,9 +1,11 @@
 namespace Hackathon.Repositories;
 
 using Hackathon.Models;
+using System.Collections.Generic;
 
 public interface IIsoDocumentRepository
 {
     Task<int> CountByYearAsync(int year);
     Task AddAsync(IsoDocument document);
+    Task<IEnumerable<IsoDocument>> GetByYearAsync(int year);
 }

--- a/Hackathon/Hackathon/Repositories/IsoDocumentRepository.cs
+++ b/Hackathon/Hackathon/Repositories/IsoDocumentRepository.cs
@@ -3,6 +3,8 @@ namespace Hackathon.Repositories;
 using Hackathon.Models;
 using Hackathon.UnitOfWork;
 using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
 
 public class IsoDocumentRepository(AppDbContext context) : IIsoDocumentRepository
 {
@@ -11,4 +13,7 @@ public class IsoDocumentRepository(AppDbContext context) : IIsoDocumentRepositor
 
     public async Task AddAsync(IsoDocument document) =>
         await context.IsoDocuments.AddAsync(document);
+
+    public async Task<IEnumerable<IsoDocument>> GetByYearAsync(int year) =>
+        await context.IsoDocuments.Where(d => d.Year == year).ToListAsync();
 }

--- a/Hackathon/Hackathon/Services/ApprovedApplicationService.cs
+++ b/Hackathon/Hackathon/Services/ApprovedApplicationService.cs
@@ -1,0 +1,69 @@
+namespace Hackathon.Services;
+
+using Hackathon.Models;
+using Hackathon.Models.Dtos;
+using Hackathon.UnitOfWork;
+using System.Collections.Generic;
+
+public class ApprovedApplicationService(IUnitOfWork unitOfWork) : IApprovedApplicationService
+{
+    private readonly IUnitOfWork _unitOfWork = unitOfWork;
+
+    public async Task<IEnumerable<ApprovedApplication>> GetAllAsync() =>
+        await _unitOfWork.ApprovedApplications.GetAllAsync();
+
+    public async Task<ApprovedApplication?> GetByIdAsync(long id) =>
+        await _unitOfWork.ApprovedApplications.GetByIdAsync(id);
+
+    public async Task<IEnumerable<ApprovedApplication>> GetByIsoDocumentIdAsync(long isoDocumentId) =>
+        await _unitOfWork.ApprovedApplications.GetByIsoDocumentIdAsync(isoDocumentId);
+
+    public async Task<ApprovedApplication> CreateAsync(ApprovedApplicationRequest request)
+    {
+        var application = new ApprovedApplication
+        {
+            IsoDocumentId = request.IsoDocumentId,
+            AppName = request.AppName,
+            AppVersion = request.AppVersion,
+            Vendor = request.Vendor,
+            Category = request.Category
+        };
+
+        await _unitOfWork.ApprovedApplications.AddAsync(application);
+        await _unitOfWork.SaveChangesAsync();
+        return application;
+    }
+
+    public async Task<bool> UpdateAsync(long id, ApprovedApplicationRequest request)
+    {
+        var application = await _unitOfWork.ApprovedApplications.GetByIdAsync(id);
+        if (application == null)
+        {
+            return false;
+        }
+
+        application.IsoDocumentId = request.IsoDocumentId;
+        application.AppName = request.AppName;
+        application.AppVersion = request.AppVersion;
+        application.Vendor = request.Vendor;
+        application.Category = request.Category;
+
+        _unitOfWork.ApprovedApplications.Update(application);
+        await _unitOfWork.SaveChangesAsync();
+        return true;
+    }
+
+    public async Task<bool> DeleteAsync(long id)
+    {
+        var application = await _unitOfWork.ApprovedApplications.GetByIdAsync(id);
+        if (application == null)
+        {
+            return false;
+        }
+
+        _unitOfWork.ApprovedApplications.Remove(application);
+        await _unitOfWork.SaveChangesAsync();
+        return true;
+    }
+}
+

--- a/Hackathon/Hackathon/Services/IApprovedApplicationService.cs
+++ b/Hackathon/Hackathon/Services/IApprovedApplicationService.cs
@@ -1,0 +1,16 @@
+namespace Hackathon.Services;
+
+using Hackathon.Models;
+using Hackathon.Models.Dtos;
+using System.Collections.Generic;
+
+public interface IApprovedApplicationService
+{
+    Task<IEnumerable<ApprovedApplication>> GetAllAsync();
+    Task<ApprovedApplication?> GetByIdAsync(long id);
+    Task<IEnumerable<ApprovedApplication>> GetByIsoDocumentIdAsync(long isoDocumentId);
+    Task<ApprovedApplication> CreateAsync(ApprovedApplicationRequest request);
+    Task<bool> UpdateAsync(long id, ApprovedApplicationRequest request);
+    Task<bool> DeleteAsync(long id);
+}
+

--- a/Hackathon/Hackathon/Services/IIsoDocumentService.cs
+++ b/Hackathon/Hackathon/Services/IIsoDocumentService.cs
@@ -6,4 +6,5 @@ using Hackathon.Models.Dtos;
 public interface IIsoDocumentService
 {
     Task<IsoDocument> UploadAsync(UploadIsoDocumentRequest request, long uploadedBy);
+    Task<IEnumerable<IsoDocument>> GetByYearAsync(int year);
 }

--- a/Hackathon/Hackathon/Services/IsoDocumentService.cs
+++ b/Hackathon/Hackathon/Services/IsoDocumentService.cs
@@ -5,6 +5,7 @@ using Hackathon.Models.Dtos;
 using Hackathon.UnitOfWork;
 using System;
 using System.Linq;
+using System.Collections.Generic;
 
 public class IsoDocumentService(IUnitOfWork unitOfWork, IFileService fileService) : IIsoDocumentService
 {
@@ -53,4 +54,7 @@ public class IsoDocumentService(IUnitOfWork unitOfWork, IFileService fileService
 
         return document;
     }
+
+    public async Task<IEnumerable<IsoDocument>> GetByYearAsync(int year) =>
+        await _unitOfWork.IsoDocuments.GetByYearAsync(year);
 }

--- a/Hackathon/Hackathon/UnitOfWork/IUnitOfWork.cs
+++ b/Hackathon/Hackathon/UnitOfWork/IUnitOfWork.cs
@@ -6,6 +6,7 @@ public interface IUnitOfWork
 {
     IUserRepository Users { get; }
     IIsoDocumentRepository IsoDocuments { get; }
+    IApprovedApplicationRepository ApprovedApplications { get; }
     Task<int> SaveChangesAsync();
 }
 

--- a/Hackathon/Hackathon/UnitOfWork/UnitOfWork.cs
+++ b/Hackathon/Hackathon/UnitOfWork/UnitOfWork.cs
@@ -2,10 +2,15 @@ namespace Hackathon.UnitOfWork;
 
 using Hackathon.Repositories;
 
-public class UnitOfWork(AppDbContext context, IUserRepository users, IIsoDocumentRepository isoDocuments) : IUnitOfWork
+public class UnitOfWork(
+    AppDbContext context,
+    IUserRepository users,
+    IIsoDocumentRepository isoDocuments,
+    IApprovedApplicationRepository approvedApplications) : IUnitOfWork
 {
     public IUserRepository Users { get; } = users;
     public IIsoDocumentRepository IsoDocuments { get; } = isoDocuments;
+    public IApprovedApplicationRepository ApprovedApplications { get; } = approvedApplications;
 
     public async Task<int> SaveChangesAsync() => await context.SaveChangesAsync();
 }


### PR DESCRIPTION
## Summary
- implement CRUD controller, service, and repository for approved applications
- expose ISO documents retrieval by year
- add endpoint to list approved applications for a specific ISO document
- wire approved application components into DI and unit of work

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2616f4648331aedd1fec46dbbfdb