### PR TITLE
Add device scan controller and service

### DIFF
--- a/Hackathon/Hackathon/Controllers/DeviceScansController.cs
+++ b/Hackathon/Hackathon/Controllers/DeviceScansController.cs
@@ -1,0 +1,27 @@
+using Hackathon.Extensions;
+using Hackathon.Models.Dtos;
+using Hackathon.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Hackathon.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class DeviceScansController(IDeviceScanService service) : ControllerBase
+{
+    [HttpPost]
+    public async Task<IActionResult> Scan(DeviceScanRequest request)
+    {
+        var userId = User.GetUserId();
+        if (userId == null)
+        {
+            return Unauthorized();
+        }
+
+        var scan = await service.ScanAsync(request, userId.Value);
+        return Ok(new { scan.Id });
+    }
+}
+

--- a/Hackathon/Hackathon/Models/Dtos/DeviceScanRequest.cs
+++ b/Hackathon/Hackathon/Models/Dtos/DeviceScanRequest.cs
@@ -1,0 +1,10 @@
+namespace Hackathon.Models.Dtos;
+
+using System.Collections.Generic;
+
+public class DeviceScanRequest
+{
+    public string? DeviceInfo { get; set; }
+    public IList<ScannedApplicationRequest> ScannedApplications { get; set; } = new List<ScannedApplicationRequest>();
+}
+

--- a/Hackathon/Hackathon/Models/Dtos/ScannedApplicationRequest.cs
+++ b/Hackathon/Hackathon/Models/Dtos/ScannedApplicationRequest.cs
@@ -1,0 +1,9 @@
+namespace Hackathon.Models.Dtos;
+
+public class ScannedApplicationRequest
+{
+    public required string AppName { get; set; }
+    public string? AppVersion { get; set; }
+    public string? Vendor { get; set; }
+}
+

--- a/Hackathon/Hackathon/Program.cs
+++ b/Hackathon/Hackathon/Program.cs
@@ -20,10 +20,13 @@ builder.Services.AddDbContext<AppDbContext>(options =>
 builder.Services.AddScoped<IUserRepository, UserRepository>();
 builder.Services.AddScoped<IIsoDocumentRepository, IsoDocumentRepository>();
 builder.Services.AddScoped<IApprovedApplicationRepository, ApprovedApplicationRepository>();
+
+builder.Services.AddScoped<IDeviceScanRepository, DeviceScanRepository>();
 builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
 builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<IIsoDocumentService, IsoDocumentService>();
 builder.Services.AddScoped<IApprovedApplicationService, ApprovedApplicationService>();
+builder.Services.AddScoped<IDeviceScanService, DeviceScanService>();
 builder.Services.AddMinio(config =>
 {
     config.WithEndpoint(builder.Configuration["Minio:Endpoint"]!)

--- a/Hackathon/Hackathon/Repositories/DeviceScanRepository.cs
+++ b/Hackathon/Hackathon/Repositories/DeviceScanRepository.cs
@@ -1,0 +1,11 @@
+namespace Hackathon.Repositories;
+
+using Hackathon.Models;
+using Hackathon.UnitOfWork;
+
+public class DeviceScanRepository(AppDbContext context) : IDeviceScanRepository
+{
+    public async Task AddAsync(DeviceScan scan) =>
+        await context.DeviceScans.AddAsync(scan);
+}
+

--- a/Hackathon/Hackathon/Repositories/IDeviceScanRepository.cs
+++ b/Hackathon/Hackathon/Repositories/IDeviceScanRepository.cs
@@ -1,0 +1,9 @@
+namespace Hackathon.Repositories;
+
+using Hackathon.Models;
+
+public interface IDeviceScanRepository
+{
+    Task AddAsync(DeviceScan scan);
+}
+

--- a/Hackathon/Hackathon/Services/DeviceScanService.cs
+++ b/Hackathon/Hackathon/Services/DeviceScanService.cs
@@ -1,0 +1,32 @@
+namespace Hackathon.Services;
+
+using Hackathon.Models;
+using Hackathon.Models.Dtos;
+using System.Linq;
+using Hackathon.UnitOfWork;
+
+public class DeviceScanService(IUnitOfWork unitOfWork) : IDeviceScanService
+{
+    private readonly IUnitOfWork _unitOfWork = unitOfWork;
+
+    public async Task<DeviceScan> ScanAsync(DeviceScanRequest request, long userId)
+    {
+        var scan = new DeviceScan
+        {
+            UserId = userId,
+            DeviceInfo = request.DeviceInfo,
+            ScannedApplications = request.ScannedApplications
+                .Select(a => new ScannedApplication
+                {
+                    AppName = a.AppName,
+                    AppVersion = a.AppVersion,
+                    Vendor = a.Vendor
+                }).ToList()
+        };
+
+        await _unitOfWork.DeviceScans.AddAsync(scan);
+        await _unitOfWork.SaveChangesAsync();
+        return scan;
+    }
+}
+

--- a/Hackathon/Hackathon/Services/IDeviceScanService.cs
+++ b/Hackathon/Hackathon/Services/IDeviceScanService.cs
@@ -1,0 +1,10 @@
+namespace Hackathon.Services;
+
+using Hackathon.Models;
+using Hackathon.Models.Dtos;
+
+public interface IDeviceScanService
+{
+    Task<DeviceScan> ScanAsync(DeviceScanRequest request, long userId);
+}
+

--- a/Hackathon/Hackathon/UnitOfWork/IUnitOfWork.cs
+++ b/Hackathon/Hackathon/UnitOfWork/IUnitOfWork.cs
@@ -7,6 +7,7 @@ public interface IUnitOfWork
     IUserRepository Users { get; }
     IIsoDocumentRepository IsoDocuments { get; }
     IApprovedApplicationRepository ApprovedApplications { get; }
+    IDeviceScanRepository DeviceScans { get; }
     Task<int> SaveChangesAsync();
 }
 

--- a/Hackathon/Hackathon/UnitOfWork/UnitOfWork.cs
+++ b/Hackathon/Hackathon/UnitOfWork/UnitOfWork.cs
@@ -6,11 +6,13 @@ public class UnitOfWork(
     AppDbContext context,
     IUserRepository users,
     IIsoDocumentRepository isoDocuments,
-    IApprovedApplicationRepository approvedApplications) : IUnitOfWork
+    IApprovedApplicationRepository approvedApplications,
+    IDeviceScanRepository deviceScans) : IUnitOfWork
 {
     public IUserRepository Users { get; } = users;
     public IIsoDocumentRepository IsoDocuments { get; } = isoDocuments;
     public IApprovedApplicationRepository ApprovedApplications { get; } = approvedApplications;
+    public IDeviceScanRepository DeviceScans { get; } = deviceScans;
 
     public async Task<int> SaveChangesAsync() => await context.SaveChangesAsync();
 }


### PR DESCRIPTION
## Summary
- add DeviceScansController with authorized endpoint to save device scans and scanned apps
- implement DeviceScanService and repository using unit of work
- wire up new services and repositories in DI

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bc2e9fdd248331b8ae94af47830595