### PR TITLE
Implement email/password login with seeding

### DIFF
--- a/Hackathon/Hackathon/Controllers/AuthController.cs
+++ b/Hackathon/Hackathon/Controllers/AuthController.cs
@@ -13,17 +13,17 @@ using Swashbuckle.AspNetCore.Annotations;
 public class AuthController(IAuthService authService) : ControllerBase
 {
     /// <summary>
-    /// Authenticates a user using Google login.
+    /// Authenticates a user using email and password.
     /// </summary>
-    /// <param name="request">The Google login details.</param>
+    /// <param name="request">The login details.</param>
     /// <returns>A JWT token if authentication succeeds.</returns>
     [HttpPost("login")]
-    [SwaggerOperation(Summary = "Authenticates a user using Google login.", Description = "Validates Google credentials and returns a JWT token.")]
-    public async Task<IActionResult> Login(GoogleLoginRequest request)
+    [SwaggerOperation(Summary = "Authenticates a user using email and password.", Description = "Validates credentials and returns a JWT token.")]
+    public async Task<IActionResult> Login(LoginRequest request)
     {
         try
         {
-            var token = await authService.LoginWithGoogleAsync(request.Email, request.ClientId);
+            var token = await authService.LoginAsync(request.Email, request.Password);
             return Ok(new { token });
         }
         catch

--- a/Hackathon/Hackathon/Extensions/SeedExtensions.cs
+++ b/Hackathon/Hackathon/Extensions/SeedExtensions.cs
@@ -1,0 +1,57 @@
+namespace Hackathon.Extensions;
+
+using Hackathon.Models;
+using Hackathon.UnitOfWork;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.AspNetCore.Hosting;
+using System.IO;
+using System.Text.Json;
+
+public static class SeedExtensions
+{
+    public static async Task SeedUsersAsync(this IHost app)
+    {
+        using var scope = app.Services.CreateScope();
+        var services = scope.ServiceProvider;
+        var env = services.GetRequiredService<IWebHostEnvironment>();
+        var unitOfWork = services.GetRequiredService<IUnitOfWork>();
+
+        var filePath = Path.Combine(env.ContentRootPath, "SeedData", "users.json");
+        if (!File.Exists(filePath)) return;
+
+        var json = await File.ReadAllTextAsync(filePath);
+        var seedUsers = JsonSerializer.Deserialize<List<UserSeed>>(json) ?? new();
+
+        foreach (var seed in seedUsers.Where(u => u.IsSeed))
+        {
+            var user = await unitOfWork.Users.GetByEmailAsync(seed.Email);
+            if (user is null)
+            {
+                user = new User
+                {
+                    Email = seed.Email,
+                    Password = seed.Password,
+                    Role = seed.Role
+                };
+                await unitOfWork.Users.AddAsync(user);
+            }
+            else
+            {
+                user.Password = seed.Password;
+                user.Role = seed.Role;
+                unitOfWork.Users.Update(user);
+            }
+        }
+
+        await unitOfWork.SaveChangesAsync();
+    }
+
+    private class UserSeed
+    {
+        public required string Email { get; set; }
+        public string Password { get; set; } = "123456";
+        public bool IsSeed { get; set; }
+        public string Role { get; set; } = "user";
+    }
+}

--- a/Hackathon/Hackathon/Hackathon.csproj
+++ b/Hackathon/Hackathon/Hackathon.csproj
@@ -20,4 +20,10 @@
     <PackageReference Include="Minio" Version="6.0.5" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="SeedData/users.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/Hackathon/Hackathon/Models/Dtos/GoogleLoginRequest.cs
+++ b/Hackathon/Hackathon/Models/Dtos/GoogleLoginRequest.cs
@@ -1,4 +1,0 @@
-namespace Hackathon.Models.Dtos;
-
-public record GoogleLoginRequest(string Email, string ClientId);
-

--- a/Hackathon/Hackathon/Models/Dtos/LoginRequest.cs
+++ b/Hackathon/Hackathon/Models/Dtos/LoginRequest.cs
@@ -1,0 +1,7 @@
+namespace Hackathon.Models.Dtos;
+
+public class LoginRequest
+{
+    public required string Email { get; set; }
+    public required string Password { get; set; }
+}

--- a/Hackathon/Hackathon/Models/User.cs
+++ b/Hackathon/Hackathon/Models/User.cs
@@ -4,6 +4,7 @@ public class User
 {
     public long Id { get; set; }
     public required string Email { get; set; }
+    public required string Password { get; set; }
     public string? FullName { get; set; }
     public string Role { get; set; } = "user";
     public string? SsoProvider { get; set; }

--- a/Hackathon/Hackathon/Program.cs
+++ b/Hackathon/Hackathon/Program.cs
@@ -1,6 +1,7 @@
 using Hackathon.Repositories;
 using Hackathon.Services;
 using Hackathon.UnitOfWork;
+using Hackathon.Extensions;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
@@ -101,6 +102,8 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();
+
+await app.SeedUsersAsync();
 
 app.Run();
 

--- a/Hackathon/Hackathon/Repositories/IUserRepository.cs
+++ b/Hackathon/Hackathon/Repositories/IUserRepository.cs
@@ -6,5 +6,6 @@ public interface IUserRepository
 {
     Task<User?> GetByEmailAsync(string email);
     Task AddAsync(User user);
+    void Update(User user);
 }
 

--- a/Hackathon/Hackathon/Repositories/UserRepository.cs
+++ b/Hackathon/Hackathon/Repositories/UserRepository.cs
@@ -10,5 +10,7 @@ public class UserRepository(AppDbContext context) : IUserRepository
         await context.Users.SingleOrDefaultAsync(u => u.Email == email);
 
     public async Task AddAsync(User user) => await context.Users.AddAsync(user);
+
+    public void Update(User user) => context.Users.Update(user);
 }
 

--- a/Hackathon/Hackathon/SeedData/users.json
+++ b/Hackathon/Hackathon/SeedData/users.json
@@ -1,0 +1,12 @@
+[
+  { "email": "admin@example.com", "password": "123456", "isSeed": true, "role": "admin" },
+  { "email": "user1@example.com", "password": "123456", "isSeed": true, "role": "user" },
+  { "email": "user2@example.com", "password": "123456", "isSeed": true, "role": "user" },
+  { "email": "user3@example.com", "password": "123456", "isSeed": true, "role": "user" },
+  { "email": "user4@example.com", "password": "123456", "isSeed": true, "role": "user" },
+  { "email": "user5@example.com", "password": "123456", "isSeed": true, "role": "user" },
+  { "email": "user6@example.com", "password": "123456", "isSeed": true, "role": "user" },
+  { "email": "user7@example.com", "password": "123456", "isSeed": true, "role": "user" },
+  { "email": "user8@example.com", "password": "123456", "isSeed": true, "role": "user" },
+  { "email": "user9@example.com", "password": "123456", "isSeed": true, "role": "user" }
+]

--- a/Hackathon/Hackathon/Services/AuthService.cs
+++ b/Hackathon/Hackathon/Services/AuthService.cs
@@ -10,20 +10,12 @@ using System.Text;
 
 public class AuthService(IUnitOfWork unitOfWork, IConfiguration configuration) : IAuthService
 {
-    public async Task<string> LoginWithGoogleAsync(string email, string clientId)
+    public async Task<string> LoginAsync(string email, string password)
     {
         var user = await unitOfWork.Users.GetByEmailAsync(email);
-        if (user is null)
+        if (user is null || user.Password != password)
         {
-            user = new User
-            {
-                Email = email,
-                SsoProvider = "Google",
-                SsoId = clientId,
-                Role = "user"
-            };
-            await unitOfWork.Users.AddAsync(user);
-            await unitOfWork.SaveChangesAsync();
+            throw new UnauthorizedAccessException();
         }
         return GenerateToken(user);
     }

--- a/Hackathon/Hackathon/Services/IAuthService.cs
+++ b/Hackathon/Hackathon/Services/IAuthService.cs
@@ -2,6 +2,6 @@ namespace Hackathon.Services;
 
 public interface IAuthService
 {
-    Task<string> LoginWithGoogleAsync(string email, string clientId);
+    Task<string> LoginAsync(string email, string password);
 }
 


### PR DESCRIPTION
## Summary
- replace Google login with email/password authentication
- add JSON-based seed mechanism to create or update users
- include seed data and invoke seeding on startup
- provide sample users.json with 10 seed records

## Testing
- `dotnet build Hackathon/Hackathon.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bce1a22074833185603777829432ec