### PR TITLE
Update device scan submission and set route to api/paring

### DIFF
--- a/Hackathon/Hackathon/Controllers/DeviceScansController.cs
+++ b/Hackathon/Hackathon/Controllers/DeviceScansController.cs
@@ -11,7 +11,7 @@ namespace Hackathon.Controllers;
 /// Handles device scan submissions.
 /// </summary>
 [ApiController]
-[Route("api/[controller]")]
+[Route("api/paring")]
 [Authorize]
 public class DeviceScansController(IDeviceScanService service) : ControllerBase
 {

--- a/Hackathon/Hackathon/Models/DeviceScan.cs
+++ b/Hackathon/Hackathon/Models/DeviceScan.cs
@@ -5,7 +5,7 @@ public class DeviceScan
     public long Id { get; set; }
     public long UserId { get; set; }
     public DateTime ScannedAt { get; set; } = DateTime.UtcNow;
-    public string? DeviceInfo { get; set; }
+    public string? SystemInfo { get; set; }
 
     public User? User { get; set; }
     public ICollection<ScannedApplication> ScannedApplications { get; set; } = new List<ScannedApplication>();

--- a/Hackathon/Hackathon/Models/Dtos/DeviceScanRequest.cs
+++ b/Hackathon/Hackathon/Models/Dtos/DeviceScanRequest.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 public class DeviceScanRequest
 {
-    public string? DeviceInfo { get; set; }
+    public required SystemInfo SystemInfo { get; set; }
     public IList<ScannedApplicationRequest> ScannedApplications { get; set; } = new List<ScannedApplicationRequest>();
 }
 

--- a/Hackathon/Hackathon/Models/Dtos/ScannedApplicationRequest.cs
+++ b/Hackathon/Hackathon/Models/Dtos/ScannedApplicationRequest.cs
@@ -2,8 +2,7 @@ namespace Hackathon.Models.Dtos;
 
 public class ScannedApplicationRequest
 {
-    public required string AppName { get; set; }
-    public string? AppVersion { get; set; }
-    public string? Vendor { get; set; }
+    public required string Name { get; set; }
+    public string? Provider { get; set; }
 }
 

--- a/Hackathon/Hackathon/Models/Dtos/SystemInfo.cs
+++ b/Hackathon/Hackathon/Models/Dtos/SystemInfo.cs
@@ -1,0 +1,11 @@
+namespace Hackathon.Models.Dtos;
+
+public class SystemInfo
+{
+    public string? MacAddress { get; set; }
+    public string? IpAddress { get; set; }
+    public string? Chip { get; set; }
+    public string? Storage { get; set; }
+    public string? Ram { get; set; }
+}
+

--- a/Hackathon/Hackathon/Services/DeviceScanService.cs
+++ b/Hackathon/Hackathon/Services/DeviceScanService.cs
@@ -3,6 +3,7 @@ namespace Hackathon.Services;
 using Hackathon.Models;
 using Hackathon.Models.Dtos;
 using System.Linq;
+using System.Text.Json;
 using Hackathon.UnitOfWork;
 
 public class DeviceScanService(IUnitOfWork unitOfWork) : IDeviceScanService
@@ -11,17 +12,19 @@ public class DeviceScanService(IUnitOfWork unitOfWork) : IDeviceScanService
 
     public async Task<DeviceScan> ScanAsync(DeviceScanRequest request, long userId)
     {
+        var applications = request.ScannedApplications
+            .Where(a => !string.Equals(a.Provider, "Apple Inc.", StringComparison.OrdinalIgnoreCase))
+            .Select(a => new ScannedApplication
+            {
+                AppName = a.Name,
+                Vendor = a.Provider
+            }).ToList();
+
         var scan = new DeviceScan
         {
             UserId = userId,
-            DeviceInfo = request.DeviceInfo,
-            ScannedApplications = request.ScannedApplications
-                .Select(a => new ScannedApplication
-                {
-                    AppName = a.AppName,
-                    AppVersion = a.AppVersion,
-                    Vendor = a.Vendor
-                }).ToList()
+            SystemInfo = JsonSerializer.Serialize(request.SystemInfo),
+            ScannedApplications = applications
         };
 
         await _unitOfWork.DeviceScans.AddAsync(scan);


### PR DESCRIPTION
## Summary
- accept detailed systemInfo payload during device scan submission
- filter out applications from Apple Inc. and map to entity
- expose device scan endpoint at `api/paring`

## Testing
- `dotnet build Hackathon/Hackathon.sln` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bce630f5548331bd351bd1f8e8dbe4