### PR TITLE
Refactor ApprovedApplication to use IsoFile and add whitelist

### DIFF
--- a/Hackathon/Hackathon/Controllers/ApprovedApplicationsController.cs
+++ b/Hackathon/Hackathon/Controllers/ApprovedApplicationsController.cs
@@ -27,15 +27,14 @@ public class ApprovedApplicationsController(IApprovedApplicationService service)
     }
 
     /// <summary>
-    /// Retrieves approved applications by ISO document identifier.
+    /// Retrieves approved applications that compose the whitelist.
     /// </summary>
-    /// <param name="isoDocumentId">The ISO document identifier.</param>
-    /// <returns>Approved applications associated with the ISO document.</returns>
-    [HttpGet("iso-document/{isoDocumentId:long}")]
-    [SwaggerOperation(Summary = "Retrieves approved applications by ISO document.", Description = "Returns approved applications linked to a specified ISO document identifier.")]
-    public async Task<IActionResult> GetByIsoDocument(long isoDocumentId)
+    /// <returns>Whitelist of approved applications.</returns>
+    [HttpGet("whitelist")]
+    [SwaggerOperation(Summary = "Retrieves whitelist.", Description = "Gets applications manually approved or linked to the active ISO document.")]
+    public async Task<IActionResult> GetWhitelist()
     {
-        var apps = await service.GetByIsoDocumentIdAsync(isoDocumentId);
+        var apps = await service.GetWhitelistAsync();
         return Ok(apps);
     }
 

--- a/Hackathon/Hackathon/Models/ApprovedApplication.cs
+++ b/Hackathon/Hackathon/Models/ApprovedApplication.cs
@@ -3,12 +3,12 @@ namespace Hackathon.Models;
 public class ApprovedApplication
 {
     public long Id { get; set; }
-    public long IsoDocumentId { get; set; }
+    public long? IsoFileId { get; set; }
     public required string AppName { get; set; }
     public string? AppVersion { get; set; }
     public string? Vendor { get; set; }
     public string? Category { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
-    public IsoDocument? IsoDocument { get; set; }
+    public IsoFile? IsoFile { get; set; }
 }

--- a/Hackathon/Hackathon/Models/Dtos/ApprovedApplicationRequest.cs
+++ b/Hackathon/Hackathon/Models/Dtos/ApprovedApplicationRequest.cs
@@ -2,7 +2,7 @@ namespace Hackathon.Models.Dtos;
 
 public class ApprovedApplicationRequest
 {
-    public long IsoDocumentId { get; set; }
+    public long? IsoFileId { get; set; }
     public required string AppName { get; set; }
     public string? AppVersion { get; set; }
     public string? Vendor { get; set; }

--- a/Hackathon/Hackathon/Models/IsoDocument.cs
+++ b/Hackathon/Hackathon/Models/IsoDocument.cs
@@ -12,5 +12,4 @@ public class IsoDocument
 
     public User? Uploader { get; set; }
     public ICollection<IsoFile> Files { get; set; } = new List<IsoFile>();
-    public ICollection<ApprovedApplication> ApprovedApplications { get; set; } = new List<ApprovedApplication>();
 }

--- a/Hackathon/Hackathon/Repositories/ApprovedApplicationRepository.cs
+++ b/Hackathon/Hackathon/Repositories/ApprovedApplicationRepository.cs
@@ -9,15 +9,40 @@ using System.Linq;
 public class ApprovedApplicationRepository(AppDbContext context) : IApprovedApplicationRepository
 {
     public async Task<IEnumerable<ApprovedApplication>> GetAllAsync() =>
-        await context.ApprovedApplications.ToListAsync();
+        await context.ApprovedApplications
+            .Include(a => a.IsoFile)
+            .ToListAsync();
 
     public async Task<ApprovedApplication?> GetByIdAsync(long id) =>
-        await context.ApprovedApplications.FindAsync(id);
-
-    public async Task<IEnumerable<ApprovedApplication>> GetByIsoDocumentIdAsync(long isoDocumentId) =>
         await context.ApprovedApplications
-            .Where(a => a.IsoDocumentId == isoDocumentId)
+            .Include(a => a.IsoFile)
+            .FirstOrDefaultAsync(a => a.Id == id);
+
+    public async Task<IEnumerable<ApprovedApplication>> GetWhitelistAsync()
+    {
+        var manualApps = await context.ApprovedApplications
+            .Where(a => a.IsoFileId == null)
+            .Include(a => a.IsoFile)
             .ToListAsync();
+
+        var activeDocument = await context.IsoDocuments
+            .Include(d => d.Files)
+            .FirstOrDefaultAsync(d => d.IsActive);
+
+        if (activeDocument == null || activeDocument.Files.Count == 0)
+        {
+            return manualApps;
+        }
+
+        var fileIds = activeDocument.Files.Select(f => f.Id).ToList();
+
+        var documentApps = await context.ApprovedApplications
+            .Where(a => a.IsoFileId != null && fileIds.Contains(a.IsoFileId.Value))
+            .Include(a => a.IsoFile)
+            .ToListAsync();
+
+        return manualApps.Concat(documentApps);
+    }
 
     public async Task AddAsync(ApprovedApplication application) =>
         await context.ApprovedApplications.AddAsync(application);

--- a/Hackathon/Hackathon/Repositories/IApprovedApplicationRepository.cs
+++ b/Hackathon/Hackathon/Repositories/IApprovedApplicationRepository.cs
@@ -7,7 +7,7 @@ public interface IApprovedApplicationRepository
 {
     Task<IEnumerable<ApprovedApplication>> GetAllAsync();
     Task<ApprovedApplication?> GetByIdAsync(long id);
-    Task<IEnumerable<ApprovedApplication>> GetByIsoDocumentIdAsync(long isoDocumentId);
+    Task<IEnumerable<ApprovedApplication>> GetWhitelistAsync();
     Task AddAsync(ApprovedApplication application);
     void Update(ApprovedApplication application);
     void Remove(ApprovedApplication application);

--- a/Hackathon/Hackathon/Services/ApprovedApplicationService.cs
+++ b/Hackathon/Hackathon/Services/ApprovedApplicationService.cs
@@ -15,14 +15,14 @@ public class ApprovedApplicationService(IUnitOfWork unitOfWork) : IApprovedAppli
     public async Task<ApprovedApplication?> GetByIdAsync(long id) =>
         await _unitOfWork.ApprovedApplications.GetByIdAsync(id);
 
-    public async Task<IEnumerable<ApprovedApplication>> GetByIsoDocumentIdAsync(long isoDocumentId) =>
-        await _unitOfWork.ApprovedApplications.GetByIsoDocumentIdAsync(isoDocumentId);
+    public async Task<IEnumerable<ApprovedApplication>> GetWhitelistAsync() =>
+        await _unitOfWork.ApprovedApplications.GetWhitelistAsync();
 
     public async Task<ApprovedApplication> CreateAsync(ApprovedApplicationRequest request)
     {
         var application = new ApprovedApplication
         {
-            IsoDocumentId = request.IsoDocumentId,
+            IsoFileId = request.IsoFileId,
             AppName = request.AppName,
             AppVersion = request.AppVersion,
             Vendor = request.Vendor,
@@ -42,7 +42,7 @@ public class ApprovedApplicationService(IUnitOfWork unitOfWork) : IApprovedAppli
             return false;
         }
 
-        application.IsoDocumentId = request.IsoDocumentId;
+        application.IsoFileId = request.IsoFileId;
         application.AppName = request.AppName;
         application.AppVersion = request.AppVersion;
         application.Vendor = request.Vendor;

--- a/Hackathon/Hackathon/Services/IApprovedApplicationService.cs
+++ b/Hackathon/Hackathon/Services/IApprovedApplicationService.cs
@@ -8,7 +8,7 @@ public interface IApprovedApplicationService
 {
     Task<IEnumerable<ApprovedApplication>> GetAllAsync();
     Task<ApprovedApplication?> GetByIdAsync(long id);
-    Task<IEnumerable<ApprovedApplication>> GetByIsoDocumentIdAsync(long isoDocumentId);
+    Task<IEnumerable<ApprovedApplication>> GetWhitelistAsync();
     Task<ApprovedApplication> CreateAsync(ApprovedApplicationRequest request);
     Task<bool> UpdateAsync(long id, ApprovedApplicationRequest request);
     Task<bool> DeleteAsync(long id);


### PR DESCRIPTION
## Summary
- replace IsoDocumentId with nullable IsoFileId in approved applications
- add repository/service/controller logic to build whitelist from manual entries and active ISO document files
- remove ISO file lookup endpoint and associated service/repository methods

## Testing
- `dotnet build Hackathon/Hackathon.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: 403 Forbidden from proxy)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf244923483319b41f5aed23e92bd