### PR TITLE
Add device scan history endpoint

### DIFF
--- a/Hackathon/Hackathon/Controllers/DeviceScansController.cs
+++ b/Hackathon/Hackathon/Controllers/DeviceScansController.cs
@@ -33,5 +33,23 @@ public class DeviceScansController(IDeviceScanService service) : ControllerBase
         var scan = await service.ScanAsync(request, userId.Value);
         return Ok(new { scan.Id });
     }
+
+    /// <summary>
+    /// Retrieves scan history for the authenticated user.
+    /// </summary>
+    /// <returns>List of device scans.</returns>
+    [HttpGet]
+    [SwaggerOperation(Summary = "Gets scan history.", Description = "Returns device scans for the authenticated user.")]
+    public async Task<IActionResult> GetHistory()
+    {
+        var userId = User.GetUserId();
+        if (userId == null)
+        {
+            return Unauthorized();
+        }
+
+        var scans = await service.GetHistoryAsync(userId.Value);
+        return Ok(scans);
+    }
 }
 

--- a/Hackathon/Hackathon/Models/Dtos/DeviceScanResponse.cs
+++ b/Hackathon/Hackathon/Models/Dtos/DeviceScanResponse.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace Hackathon.Models.Dtos;
+
+public class DeviceScanResponse
+{
+    public long Id { get; set; }
+    public DateTime ScannedAt { get; set; }
+    public string? DeviceInfo { get; set; }
+    public List<ScannedApplicationResponse> ScannedApplications { get; set; } = new();
+    public List<ViolationResponse> Violations { get; set; } = new();
+}

--- a/Hackathon/Hackathon/Models/Dtos/ScannedApplicationResponse.cs
+++ b/Hackathon/Hackathon/Models/Dtos/ScannedApplicationResponse.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Hackathon.Models.Dtos;
+
+public class ScannedApplicationResponse
+{
+    public long Id { get; set; }
+    public string AppName { get; set; } = string.Empty;
+    public string? AppVersion { get; set; }
+    public string? Vendor { get; set; }
+    public bool? IsApproved { get; set; }
+    public DateTime CheckedAt { get; set; }
+}

--- a/Hackathon/Hackathon/Models/Dtos/ViolationDetailResponse.cs
+++ b/Hackathon/Hackathon/Models/Dtos/ViolationDetailResponse.cs
@@ -1,0 +1,7 @@
+namespace Hackathon.Models.Dtos;
+
+public class ViolationDetailResponse
+{
+    public long Id { get; set; }
+    public long ScannedAppId { get; set; }
+}

--- a/Hackathon/Hackathon/Models/Dtos/ViolationResponse.cs
+++ b/Hackathon/Hackathon/Models/Dtos/ViolationResponse.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace Hackathon.Models.Dtos;
+
+public class ViolationResponse
+{
+    public long Id { get; set; }
+    public int TotalViolations { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public List<ViolationDetailResponse> Details { get; set; } = new();
+}

--- a/Hackathon/Hackathon/Repositories/DeviceScanRepository.cs
+++ b/Hackathon/Hackathon/Repositories/DeviceScanRepository.cs
@@ -2,10 +2,21 @@ namespace Hackathon.Repositories;
 
 using Hackathon.Models;
 using Hackathon.UnitOfWork;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
 
 public class DeviceScanRepository(AppDbContext context) : IDeviceScanRepository
 {
     public async Task AddAsync(DeviceScan scan) =>
         await context.DeviceScans.AddAsync(scan);
+
+    public async Task<IEnumerable<DeviceScan>> GetByUserIdAsync(long userId) =>
+        await context.DeviceScans
+            .Where(d => d.UserId == userId)
+            .Include(d => d.ScannedApplications)
+            .Include(d => d.Violations)
+                .ThenInclude(v => v.Details)
+            .ToListAsync();
 }
 

--- a/Hackathon/Hackathon/Repositories/IDeviceScanRepository.cs
+++ b/Hackathon/Hackathon/Repositories/IDeviceScanRepository.cs
@@ -1,9 +1,11 @@
 namespace Hackathon.Repositories;
 
 using Hackathon.Models;
+using System.Collections.Generic;
 
 public interface IDeviceScanRepository
 {
     Task AddAsync(DeviceScan scan);
+    Task<IEnumerable<DeviceScan>> GetByUserIdAsync(long userId);
 }
 

--- a/Hackathon/Hackathon/Services/DeviceScanService.cs
+++ b/Hackathon/Hackathon/Services/DeviceScanService.cs
@@ -5,6 +5,7 @@ using Hackathon.Models.Dtos;
 using Hackathon.UnitOfWork;
 using System.Linq;
 using System.Text.Json;
+using System.Collections.Generic;
 
 public class DeviceScanService(IUnitOfWork unitOfWork) : IDeviceScanService
 {
@@ -30,6 +31,39 @@ public class DeviceScanService(IUnitOfWork unitOfWork) : IDeviceScanService
         await _unitOfWork.DeviceScans.AddAsync(scan);
         await _unitOfWork.SaveChangesAsync();
         return scan;
+    }
+
+    public async Task<IEnumerable<DeviceScanResponse>> GetHistoryAsync(long userId)
+    {
+        var scans = await _unitOfWork.DeviceScans.GetByUserIdAsync(userId);
+
+        return scans.Select(scan => new DeviceScanResponse
+        {
+            Id = scan.Id,
+            ScannedAt = scan.ScannedAt,
+            DeviceInfo = scan.DeviceInfo,
+            ScannedApplications = scan.ScannedApplications.Select(app => new ScannedApplicationResponse
+            {
+                Id = app.Id,
+                AppName = app.AppName,
+                AppVersion = app.AppVersion,
+                Vendor = app.Vendor,
+                IsApproved = app.IsApproved,
+                CheckedAt = app.CheckedAt
+            }).ToList(),
+            Violations = scan.Violations.Select(v => new ViolationResponse
+            {
+                Id = v.Id,
+                TotalViolations = v.TotalViolations,
+                Status = v.Status,
+                CreatedAt = v.CreatedAt,
+                Details = v.Details.Select(d => new ViolationDetailResponse
+                {
+                    Id = d.Id,
+                    ScannedAppId = d.ScannedAppId
+                }).ToList()
+            }).ToList()
+        }).ToList();
     }
 }
 

--- a/Hackathon/Hackathon/Services/IDeviceScanService.cs
+++ b/Hackathon/Hackathon/Services/IDeviceScanService.cs
@@ -2,9 +2,11 @@ namespace Hackathon.Services;
 
 using Hackathon.Models;
 using Hackathon.Models.Dtos;
+using System.Collections.Generic;
 
 public interface IDeviceScanService
 {
     Task<DeviceScan> ScanAsync(DeviceScanRequest request, long userId);
+    Task<IEnumerable<DeviceScanResponse>> GetHistoryAsync(long userId);
 }
 


### PR DESCRIPTION
## Summary
- add GET endpoint to retrieve device scan history for authenticated user
- introduce DTOs for scans, applications, and violations
- implement repository and service methods to fetch scans with related data

## Testing
- `dotnet build Hackathon/Hackathon.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf7090c3483319e7247632eee787a