### PR TITLE
Switch user email lookup to FirstOrDefault

### DIFF
--- a/Hackathon/Hackathon/Repositories/UserRepository.cs
+++ b/Hackathon/Hackathon/Repositories/UserRepository.cs
@@ -6,8 +6,13 @@ using Microsoft.EntityFrameworkCore;
 
 public class UserRepository(AppDbContext context) : IUserRepository
 {
-    public async Task<User?> GetByEmailAsync(string email) =>
-        await context.Users.SingleOrDefaultAsync(u => u.Email == email);
+    public async Task<User?> GetByEmailAsync(string email)
+    {
+        return await context.Users
+            .Where(u => u.Email == email)
+            .OrderByDescending(u => u.CreatedAt)
+            .FirstOrDefaultAsync();
+    }
 
     public async Task AddAsync(User user) => await context.Users.AddAsync(user);
 


### PR DESCRIPTION
## Summary
- avoid SingleOrDefault exceptions by using FirstOrDefault when fetching a user by email
- return the most recently created user when duplicates exist

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0179343c8331a3494f2aa192b0bb