### PR TITLE
Fix foreign key naming for uploader and violation details

### DIFF
--- a/Hackathon/Hackathon/Models/Dtos/ViolationDetailResponse.cs
+++ b/Hackathon/Hackathon/Models/Dtos/ViolationDetailResponse.cs
@@ -3,5 +3,5 @@ namespace Hackathon.Models.Dtos;
 public class ViolationDetailResponse
 {
     public long Id { get; set; }
-    public long ScannedAppId { get; set; }
+    public long ScannedApplicationId { get; set; }
 }

--- a/Hackathon/Hackathon/Models/IsoDocument.cs
+++ b/Hackathon/Hackathon/Models/IsoDocument.cs
@@ -12,7 +12,7 @@ public class IsoDocument
     [Column("year")]
     public int Year { get; set; }
     [Column("uploaded_by")]
-    public long? UploadedBy { get; set; }
+    public long? UploaderId { get; set; }
     [Column("uploaded_at")]
     public DateTime UploadedAt { get; set; } = DateTime.UtcNow;
     [Column("notes")]

--- a/Hackathon/Hackathon/Models/ViolationDetail.cs
+++ b/Hackathon/Hackathon/Models/ViolationDetail.cs
@@ -10,7 +10,7 @@ public class ViolationDetail
     [Column("violation_id")]
     public long ViolationId { get; set; }
     [Column("scanned_app_id")]
-    public long ScannedAppId { get; set; }
+    public long ScannedApplicationId { get; set; }
 
     public Violation? Violation { get; set; }
     public ScannedApplication? ScannedApplication { get; set; }

--- a/Hackathon/Hackathon/Services/DeviceScanService.cs
+++ b/Hackathon/Hackathon/Services/DeviceScanService.cs
@@ -90,7 +90,7 @@ public class DeviceScanService(IUnitOfWork unitOfWork) : IDeviceScanService
                 Details = v.Details.Select(d => new ViolationDetailResponse
                 {
                     Id = d.Id,
-                    ScannedAppId = d.ScannedAppId
+                    ScannedApplicationId = d.ScannedApplicationId
                 }).ToList()
             }).ToList()
         }).ToList();

--- a/Hackathon/Hackathon/Services/IIsoDocumentService.cs
+++ b/Hackathon/Hackathon/Services/IIsoDocumentService.cs
@@ -5,6 +5,6 @@ using Hackathon.Models.Dtos;
 
 public interface IIsoDocumentService
 {
-    Task<IsoDocument> UploadAsync(UploadIsoDocumentRequest request, long uploadedBy);
+    Task<IsoDocument> UploadAsync(UploadIsoDocumentRequest request, long uploaderId);
     Task<IEnumerable<IsoDocument>> GetByYearAsync(int year);
 }

--- a/Hackathon/Hackathon/Services/IsoDocumentService.cs
+++ b/Hackathon/Hackathon/Services/IsoDocumentService.cs
@@ -13,7 +13,7 @@ public class IsoDocumentService(IUnitOfWork unitOfWork, IFileService fileService
     private readonly IFileService _fileService = fileService;
     private const long MaxRequestSize = 1L * 1024 * 1024 * 1024; // 1GB
 
-    public async Task<IsoDocument> UploadAsync(UploadIsoDocumentRequest request, long uploadedBy)
+    public async Task<IsoDocument> UploadAsync(UploadIsoDocumentRequest request, long uploaderId)
     {
         if (request.Files.Sum(f => f.Length) > MaxRequestSize)
         {
@@ -36,7 +36,7 @@ public class IsoDocumentService(IUnitOfWork unitOfWork, IFileService fileService
             Year = request.Year,
             Notes = request.Notes,
             Version = version,
-            UploadedBy = uploadedBy
+            UploaderId = uploaderId
         };
 
         foreach (var file in request.Files)


### PR DESCRIPTION
## Summary
- Align IsoDocument uploader foreign key with entity naming
- Rename ViolationDetail scanned app FK for proper navigation mapping

## Testing
- `dotnet build Hackathon/Hackathon.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68bd18f380208331aed819ed478f60a5