### PR TITLE
Fix Admin/Analyst policy mapping

### DIFF
--- a/Hackathon/Hackathon/Extensions/ClaimsPrincipalExtensions.cs
+++ b/Hackathon/Hackathon/Extensions/ClaimsPrincipalExtensions.cs
@@ -24,7 +24,7 @@ public static class ClaimsPrincipalExtensions
             return null;
         }
 
-        return user.FindFirst(ClaimTypes.Role)?.Value;
+        return user.FindFirst("role")?.Value;
     }
 }
 

--- a/Hackathon/Hackathon/Program.cs
+++ b/Hackathon/Hackathon/Program.cs
@@ -88,7 +88,7 @@ builder.Services.AddAuthentication(options =>
 builder.Services.AddAuthorization(options =>
 {
     options.AddPolicy("AdminOrAnalyst", policy =>
-        policy.RequireRole("admin", "analyst"));
+        policy.RequireClaim("role", "admin", "analyst"));
 });
 
 var app = builder.Build();


### PR DESCRIPTION
## Summary
- Align AdminOrAnalyst policy with role claim
- Read user roles directly from JWT "role" claim

## Testing
- `dotnet build Hackathon/Hackathon.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1f9853c483318f8ea73d56b1a327