### PR TITLE
Add ProducesResponseType attributes to controller endpoints

### DIFF
--- a/Hackathon/Hackathon/Controllers/ApprovedApplicationsController.cs
+++ b/Hackathon/Hackathon/Controllers/ApprovedApplicationsController.cs
@@ -1,6 +1,9 @@
+using System.Collections.Generic;
+using Hackathon.Models;
 using Hackathon.Models.Dtos;
 using Hackathon.Services;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -20,6 +23,9 @@ public class ApprovedApplicationsController(IApprovedApplicationService service)
     /// <returns>All approved applications.</returns>
     [HttpGet]
     [SwaggerOperation(Summary = "Retrieves all approved applications.", Description = "Gets the list of every approved application in the system.")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<ApprovedApplication>))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> GetAll()
     {
         var apps = await service.GetAllAsync();
@@ -32,6 +38,9 @@ public class ApprovedApplicationsController(IApprovedApplicationService service)
     /// <returns>Whitelist of approved applications.</returns>
     [HttpGet("whitelist")]
     [SwaggerOperation(Summary = "Retrieves whitelist.", Description = "Gets applications manually approved or linked to the active ISO document.")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<ApprovedApplication>))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> GetWhitelist()
     {
         var apps = await service.GetWhitelistAsync();
@@ -45,6 +54,10 @@ public class ApprovedApplicationsController(IApprovedApplicationService service)
     /// <returns>The approved application if found.</returns>
     [HttpGet("{id:long}")]
     [SwaggerOperation(Summary = "Retrieves an approved application by ID.", Description = "Gets a single approved application matching the provided identifier.")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ApprovedApplication))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> Get(long id)
     {
         var app = await service.GetByIdAsync(id);
@@ -62,6 +75,10 @@ public class ApprovedApplicationsController(IApprovedApplicationService service)
     /// <returns>The created approved application.</returns>
     [HttpPost]
     [SwaggerOperation(Summary = "Creates a new approved application.", Description = "Adds a new approved application using the provided request data.")]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(ApprovedApplication))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> Create(ApprovedApplicationRequest request)
     {
         var app = await service.CreateAsync(request);
@@ -76,6 +93,10 @@ public class ApprovedApplicationsController(IApprovedApplicationService service)
     /// <returns>No content if update succeeds.</returns>
     [HttpPut("{id:long}")]
     [SwaggerOperation(Summary = "Updates an existing approved application.", Description = "Replaces an approved application's information with new values.")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> Update(long id, ApprovedApplicationRequest request)
     {
         var success = await service.UpdateAsync(id, request);
@@ -93,6 +114,10 @@ public class ApprovedApplicationsController(IApprovedApplicationService service)
     /// <returns>No content if deletion succeeds.</returns>
     [HttpDelete("{id:long}")]
     [SwaggerOperation(Summary = "Deletes an approved application.", Description = "Removes an approved application from the system.")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> Delete(long id)
     {
         var success = await service.DeleteAsync(id);

--- a/Hackathon/Hackathon/Controllers/AuthController.cs
+++ b/Hackathon/Hackathon/Controllers/AuthController.cs
@@ -2,6 +2,7 @@ namespace Hackathon.Controllers;
 
 using Hackathon.Models.Dtos;
 using Hackathon.Services;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -19,6 +20,9 @@ public class AuthController(IAuthService authService) : ControllerBase
     /// <returns>A JWT token if authentication succeeds.</returns>
     [HttpPost("login")]
     [SwaggerOperation(Summary = "Authenticates a user using email and password.", Description = "Validates credentials and returns a JWT token.")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(object))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> Login(LoginRequest request)
     {
         try

--- a/Hackathon/Hackathon/Controllers/DeviceScansController.cs
+++ b/Hackathon/Hackathon/Controllers/DeviceScansController.cs
@@ -1,7 +1,9 @@
+using System.Collections.Generic;
 using Hackathon.Extensions;
 using Hackathon.Models.Dtos;
 using Hackathon.Services;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -22,6 +24,9 @@ public class DeviceScansController(IDeviceScanService service) : ControllerBase
     /// <returns>The identifier of the created scan.</returns>
     [HttpPost]
     [SwaggerOperation(Summary = "Submits a device scan.", Description = "Registers a new device scan for the authenticated user.")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(object))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> Scan(DeviceScanRequest request)
     {
         var userId = User.GetUserId();
@@ -40,6 +45,8 @@ public class DeviceScansController(IDeviceScanService service) : ControllerBase
     /// <returns>List of device scans.</returns>
     [HttpGet]
     [SwaggerOperation(Summary = "Gets scan history.", Description = "Returns device scans for the authenticated user.")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<DeviceScanResponse>))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> GetHistory()
     {
         var userId = User.GetUserId();

--- a/Hackathon/Hackathon/Controllers/IsoDocumentsController.cs
+++ b/Hackathon/Hackathon/Controllers/IsoDocumentsController.cs
@@ -1,9 +1,12 @@
+using System;
+using System.Collections.Generic;
 using Hackathon.Extensions;
+using Hackathon.Models;
 using Hackathon.Models.Dtos;
 using Hackathon.Services;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using System;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace Hackathon.Controllers;
@@ -30,6 +33,9 @@ public class IsoDocumentsController : ControllerBase
     /// <returns>ISO documents for the specified year.</returns>
     [HttpGet("year/{year:int}")]
     [SwaggerOperation(Summary = "Retrieves ISO documents by year.", Description = "Gets all ISO documents uploaded for a specific year.")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<IsoDocument>))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> GetByYear(int year)
     {
         var documents = await _service.GetByYearAsync(year);
@@ -44,6 +50,10 @@ public class IsoDocumentsController : ControllerBase
     [HttpPost]
     [RequestSizeLimit(1L * 1024 * 1024 * 1024)]
     [SwaggerOperation(Summary = "Uploads a new ISO document.", Description = "Stores a new ISO document and returns its identifier and version.")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(object))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> Upload([FromForm] UploadIsoDocumentRequest request)
     {
         var userId = User.GetUserId();


### PR DESCRIPTION
## Summary
- Document response codes for approved application operations
- Specify possible outcomes for auth, device scan, and ISO document endpoints

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403; unable to install dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68bd247e213083318051ff5e39f92898