### PR TITLE
feat: expand iso document management

### DIFF
--- a/Hackathon/Hackathon/Controllers/IsoDocumentsController.cs
+++ b/Hackathon/Hackathon/Controllers/IsoDocumentsController.cs
@@ -24,10 +24,41 @@ public class IsoDocumentsController : ControllerBase
     }
 
     /// <summary>
+    /// Retrieves all ISO documents.
+    /// </summary>
+    [HttpGet]
+    [SwaggerOperation(Summary = "Retrieves all ISO documents.", Description = "Gets every ISO document in the system.")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<IsoDocument>))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetAll()
+    {
+        var docs = await _service.GetAllAsync();
+        return Ok(docs);
+    }
+
+    /// <summary>
+    /// Retrieves an ISO document by identifier.
+    /// </summary>
+    [HttpGet("{id:long}")]
+    [SwaggerOperation(Summary = "Retrieves an ISO document by ID.", Description = "Gets a single ISO document matching the provided identifier.")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IsoDocument))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> Get(long id)
+    {
+        var doc = await _service.GetByIdAsync(id);
+        if (doc == null)
+        {
+            return NotFound();
+        }
+        return Ok(doc);
+    }
+
+    /// <summary>
     /// Retrieves ISO documents by year.
     /// </summary>
-    /// <param name="year">The year of the ISO documents.</param>
-    /// <returns>ISO documents for the specified year.</returns>
     [HttpGet("year/{year:int}")]
     [SwaggerOperation(Summary = "Retrieves ISO documents by year.", Description = "Gets all ISO documents uploaded for a specific year.")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<IsoDocument>))]
@@ -40,18 +71,93 @@ public class IsoDocumentsController : ControllerBase
     }
 
     /// <summary>
-    /// Uploads a new ISO document.
+    /// Creates a new ISO document.
     /// </summary>
-    /// <param name="request">The ISO document upload request.</param>
-    /// <returns>The identifier and version of the uploaded document.</returns>
     [HttpPost]
+    [SwaggerOperation(Summary = "Creates a new ISO document.", Description = "Adds a new ISO document without files.")]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(IsoDocument))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> Create(IsoDocumentRequest request)
+    {
+        var userId = User.GetUserId();
+        if (userId == null)
+        {
+            return Unauthorized();
+        }
+
+        var document = await _service.CreateAsync(request, userId.Value);
+        return CreatedAtAction(nameof(Get), new { id = document.Id }, document);
+    }
+
+    /// <summary>
+    /// Updates an existing ISO document.
+    /// </summary>
+    [HttpPut("{id:long}")]
+    [SwaggerOperation(Summary = "Updates an existing ISO document.", Description = "Replaces ISO document information with new values.")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> Update(long id, IsoDocumentRequest request)
+    {
+        var success = await _service.UpdateAsync(id, request);
+        if (!success)
+        {
+            return NotFound();
+        }
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Deletes an ISO document.
+    /// </summary>
+    [HttpDelete("{id:long}")]
+    [SwaggerOperation(Summary = "Deletes an ISO document.", Description = "Removes an ISO document from the system.")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> Delete(long id)
+    {
+        var success = await _service.DeleteAsync(id);
+        if (!success)
+        {
+            return NotFound();
+        }
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Enables an ISO document as active.
+    /// </summary>
+    [HttpPost("{id:long}/enable")]
+    [SwaggerOperation(Summary = "Enables an ISO document.", Description = "Marks the specified ISO document as active and disables others.")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> Enable(long id)
+    {
+        var success = await _service.EnableAsync(id);
+        if (!success)
+        {
+            return NotFound();
+        }
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Uploads files to an existing ISO document.
+    /// </summary>
+    [HttpPost("{id:long}/upload")]
     [RequestSizeLimit(1L * 1024 * 1024 * 1024)]
-    [SwaggerOperation(Summary = "Uploads a new ISO document.", Description = "Stores a new ISO document and returns its identifier and version.")]
+    [SwaggerOperation(Summary = "Uploads files to an ISO document.", Description = "Stores files for an existing ISO document and returns the document.")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IsoDocument))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    public async Task<IActionResult> Upload([FromForm] UploadIsoDocumentRequest request)
+    public async Task<IActionResult> Upload(long id, [FromForm] UploadIsoDocumentRequest request)
     {
         var userId = User.GetUserId();
         if (userId == null)
@@ -61,7 +167,7 @@ public class IsoDocumentsController : ControllerBase
 
         try
         {
-            var document = await _service.UploadAsync(request, userId.Value);
+            var document = await _service.UploadAsync(id, request, userId.Value);
             return Ok(document);
         }
         catch (InvalidOperationException ex)

--- a/Hackathon/Hackathon/Models/Dtos/IsoDocumentRequest.cs
+++ b/Hackathon/Hackathon/Models/Dtos/IsoDocumentRequest.cs
@@ -1,0 +1,8 @@
+namespace Hackathon.Models.Dtos;
+
+public class IsoDocumentRequest
+{
+    public int Year { get; set; }
+    public string? Notes { get; set; }
+}
+

--- a/Hackathon/Hackathon/Models/Dtos/UploadIsoDocumentRequest.cs
+++ b/Hackathon/Hackathon/Models/Dtos/UploadIsoDocumentRequest.cs
@@ -4,8 +4,6 @@ using Microsoft.AspNetCore.Http;
 
 public class UploadIsoDocumentRequest
 {
-    public int Year { get; set; }
-    public string? Notes { get; set; }
     public IFormFileCollection Files { get; set; } = default!;
 }
 

--- a/Hackathon/Hackathon/Repositories/IIsoDocumentRepository.cs
+++ b/Hackathon/Hackathon/Repositories/IIsoDocumentRepository.cs
@@ -8,4 +8,7 @@ public interface IIsoDocumentRepository
     Task<int> CountByYearAsync(int year);
     Task AddAsync(IsoDocument document);
     Task<IEnumerable<IsoDocument>> GetByYearAsync(int year);
+    Task<IEnumerable<IsoDocument>> GetAllAsync();
+    Task<IsoDocument?> GetByIdAsync(long id);
+    void Remove(IsoDocument document);
 }

--- a/Hackathon/Hackathon/Repositories/IsoDocumentRepository.cs
+++ b/Hackathon/Hackathon/Repositories/IsoDocumentRepository.cs
@@ -16,4 +16,13 @@ public class IsoDocumentRepository(AppDbContext context) : IIsoDocumentRepositor
 
     public async Task<IEnumerable<IsoDocument>> GetByYearAsync(int year) =>
         await context.IsoDocuments.Where(d => d.Year == year).ToListAsync();
+
+    public async Task<IEnumerable<IsoDocument>> GetAllAsync() =>
+        await context.IsoDocuments.Include(d => d.Files).ToListAsync();
+
+    public async Task<IsoDocument?> GetByIdAsync(long id) =>
+        await context.IsoDocuments.Include(d => d.Files).FirstOrDefaultAsync(d => d.Id == id);
+
+    public void Remove(IsoDocument document) =>
+        context.IsoDocuments.Remove(document);
 }

--- a/Hackathon/Hackathon/Services/IIsoDocumentService.cs
+++ b/Hackathon/Hackathon/Services/IIsoDocumentService.cs
@@ -5,6 +5,12 @@ using Hackathon.Models.Dtos;
 
 public interface IIsoDocumentService
 {
-    Task<IsoDocument> UploadAsync(UploadIsoDocumentRequest request, long uploaderId);
+    Task<IsoDocument> CreateAsync(IsoDocumentRequest request, long uploaderId);
+    Task<IEnumerable<IsoDocument>> GetAllAsync();
+    Task<IsoDocument?> GetByIdAsync(long id);
+    Task<bool> UpdateAsync(long id, IsoDocumentRequest request);
+    Task<bool> DeleteAsync(long id);
+    Task<bool> EnableAsync(long id);
+    Task<IsoDocument> UploadAsync(long documentId, UploadIsoDocumentRequest request, long uploaderId);
     Task<IEnumerable<IsoDocument>> GetByYearAsync(int year);
 }

--- a/Hackathon/Hackathon/Services/IsoDocumentService.cs
+++ b/Hackathon/Hackathon/Services/IsoDocumentService.cs
@@ -13,7 +13,70 @@ public class IsoDocumentService(IUnitOfWork unitOfWork, IFileService fileService
     private readonly IFileService _fileService = fileService;
     private const long MaxRequestSize = 1L * 1024 * 1024 * 1024; // 1GB
 
-    public async Task<IsoDocument> UploadAsync(UploadIsoDocumentRequest request, long uploaderId)
+    public async Task<IsoDocument> CreateAsync(IsoDocumentRequest request, long uploaderId)
+    {
+        var count = await _unitOfWork.IsoDocuments.CountByYearAsync(request.Year);
+        var version = $"ISO_{request.Year}_v{count + 1}";
+        var document = new IsoDocument
+        {
+            Year = request.Year,
+            Notes = request.Notes,
+            Version = version,
+            UploaderId = uploaderId
+        };
+        await _unitOfWork.IsoDocuments.AddAsync(document);
+        await _unitOfWork.SaveChangesAsync();
+        return document;
+    }
+
+    public async Task<IEnumerable<IsoDocument>> GetAllAsync() =>
+        await _unitOfWork.IsoDocuments.GetAllAsync();
+
+    public async Task<IsoDocument?> GetByIdAsync(long id) =>
+        await _unitOfWork.IsoDocuments.GetByIdAsync(id);
+
+    public async Task<bool> UpdateAsync(long id, IsoDocumentRequest request)
+    {
+        var document = await _unitOfWork.IsoDocuments.GetByIdAsync(id);
+        if (document == null)
+        {
+            return false;
+        }
+        document.Year = request.Year;
+        document.Notes = request.Notes;
+        await _unitOfWork.SaveChangesAsync();
+        return true;
+    }
+
+    public async Task<bool> DeleteAsync(long id)
+    {
+        var document = await _unitOfWork.IsoDocuments.GetByIdAsync(id);
+        if (document == null)
+        {
+            return false;
+        }
+        _unitOfWork.IsoDocuments.Remove(document);
+        await _unitOfWork.SaveChangesAsync();
+        return true;
+    }
+
+    public async Task<bool> EnableAsync(long id)
+    {
+        var document = await _unitOfWork.IsoDocuments.GetByIdAsync(id);
+        if (document == null)
+        {
+            return false;
+        }
+        var all = await _unitOfWork.IsoDocuments.GetAllAsync();
+        foreach (var doc in all)
+        {
+            doc.IsActive = doc.Id == id;
+        }
+        await _unitOfWork.SaveChangesAsync();
+        return true;
+    }
+
+    public async Task<IsoDocument> UploadAsync(long documentId, UploadIsoDocumentRequest request, long uploaderId)
     {
         if (request.Files.Sum(f => f.Length) > MaxRequestSize)
         {
@@ -28,16 +91,10 @@ public class IsoDocumentService(IUnitOfWork unitOfWork, IFileService fileService
             }
         }
 
-        var count = await _unitOfWork.IsoDocuments.CountByYearAsync(request.Year);
-        var version = $"ISO_{request.Year}_v{count + 1}";
+        var document = await _unitOfWork.IsoDocuments.GetByIdAsync(documentId)
+            ?? throw new InvalidOperationException("ISO document not found.");
 
-        var document = new IsoDocument
-        {
-            Year = request.Year,
-            Notes = request.Notes,
-            Version = version,
-            UploaderId = uploaderId
-        };
+        document.UploaderId ??= uploaderId;
 
         foreach (var file in request.Files)
         {
@@ -49,12 +106,11 @@ public class IsoDocumentService(IUnitOfWork unitOfWork, IFileService fileService
             });
         }
 
-        await _unitOfWork.IsoDocuments.AddAsync(document);
         await _unitOfWork.SaveChangesAsync();
-
         return document;
     }
 
     public async Task<IEnumerable<IsoDocument>> GetByYearAsync(int year) =>
         await _unitOfWork.IsoDocuments.GetByYearAsync(year);
 }
+


### PR DESCRIPTION
## Summary
- add DTOs and repository/service methods to manage ISO documents
- support enabling one active ISO document and uploading files by document ID
- expose CRUD, enable, and upload endpoints for ISO documents

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd449a79ec833187fa3564e6dcec94