### PR TITLE
Add endpoint to list ISO files by document

### DIFF
--- a/Hackathon/Hackathon/Controllers/IsoDocumentsController.cs
+++ b/Hackathon/Hackathon/Controllers/IsoDocumentsController.cs
@@ -71,6 +71,25 @@ public class IsoDocumentsController : ControllerBase
     }
 
     /// <summary>
+    /// Retrieves files of an ISO document.
+    /// </summary>
+    [HttpGet("{id:long}/files")]
+    [SwaggerOperation(Summary = "Retrieves files for an ISO document.", Description = "Gets all files associated with the specified ISO document.")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<IsoFile>))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetFiles(long id)
+    {
+        var files = await _service.GetFilesAsync(id);
+        if (files == null)
+        {
+            return NotFound();
+        }
+        return Ok(files);
+    }
+
+    /// <summary>
     /// Creates a new ISO document.
     /// </summary>
     [HttpPost]

--- a/Hackathon/Hackathon/Repositories/IIsoDocumentRepository.cs
+++ b/Hackathon/Hackathon/Repositories/IIsoDocumentRepository.cs
@@ -10,5 +10,7 @@ public interface IIsoDocumentRepository
     Task<IEnumerable<IsoDocument>> GetByYearAsync(int year);
     Task<IEnumerable<IsoDocument>> GetAllAsync();
     Task<IsoDocument?> GetByIdAsync(long id);
+    Task<IsoDocument?> GetByIdWithFilesAsync(long id);
+    Task<IEnumerable<IsoFile>> GetFilesByDocumentIdAsync(long documentId);
     void Remove(IsoDocument document);
 }

--- a/Hackathon/Hackathon/Repositories/IsoDocumentRepository.cs
+++ b/Hackathon/Hackathon/Repositories/IsoDocumentRepository.cs
@@ -21,7 +21,16 @@ public class IsoDocumentRepository(AppDbContext context) : IIsoDocumentRepositor
         await context.IsoDocuments.Include(d => d.Files).ToListAsync();
 
     public async Task<IsoDocument?> GetByIdAsync(long id) =>
-        await context.IsoDocuments.Include(d => d.Files).FirstOrDefaultAsync(d => d.Id == id);
+        await context.IsoDocuments.FirstOrDefaultAsync(d => d.Id == id);
+
+    public async Task<IsoDocument?> GetByIdWithFilesAsync(long id) =>
+        await context.IsoDocuments.Include(d => d.Files)
+            .FirstOrDefaultAsync(d => d.Id == id);
+
+    public async Task<IEnumerable<IsoFile>> GetFilesByDocumentIdAsync(long documentId) =>
+        await context.IsoFiles
+            .Where(f => f.IsoDocumentId == documentId)
+            .ToListAsync();
 
     public void Remove(IsoDocument document) =>
         context.IsoDocuments.Remove(document);

--- a/Hackathon/Hackathon/Services/IIsoDocumentService.cs
+++ b/Hackathon/Hackathon/Services/IIsoDocumentService.cs
@@ -13,4 +13,5 @@ public interface IIsoDocumentService
     Task<bool> EnableAsync(long id);
     Task<IsoDocument> UploadAsync(long documentId, UploadIsoDocumentRequest request, long uploaderId);
     Task<IEnumerable<IsoDocument>> GetByYearAsync(int year);
+    Task<IEnumerable<IsoFile>?> GetFilesAsync(long documentId);
 }

--- a/Hackathon/Hackathon/Services/IsoDocumentService.cs
+++ b/Hackathon/Hackathon/Services/IsoDocumentService.cs
@@ -91,7 +91,7 @@ public class IsoDocumentService(IUnitOfWork unitOfWork, IFileService fileService
             }
         }
 
-        var document = await _unitOfWork.IsoDocuments.GetByIdAsync(documentId)
+        var document = await _unitOfWork.IsoDocuments.GetByIdWithFilesAsync(documentId)
             ?? throw new InvalidOperationException("ISO document not found.");
 
         document.UploaderId ??= uploaderId;
@@ -108,6 +108,16 @@ public class IsoDocumentService(IUnitOfWork unitOfWork, IFileService fileService
 
         await _unitOfWork.SaveChangesAsync();
         return document;
+    }
+
+    public async Task<IEnumerable<IsoFile>?> GetFilesAsync(long documentId)
+    {
+        var document = await _unitOfWork.IsoDocuments.GetByIdAsync(documentId);
+        if (document == null)
+        {
+            return null;
+        }
+        return await _unitOfWork.IsoDocuments.GetFilesByDocumentIdAsync(documentId);
     }
 
     public async Task<IEnumerable<IsoDocument>> GetByYearAsync(int year) =>


### PR DESCRIPTION
## Summary
- extend ISO document repository with method to fetch document including files
- load associated files in service when uploading and listing document files
- query ISO file list directly without relying on navigation include

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bd487e160c833192180c1c31a2982c