### PR TITLE
Add endpoint to list users with latest device scan

### DIFF
--- a/Hackathon/Hackathon/Controllers/UsersController.cs
+++ b/Hackathon/Hackathon/Controllers/UsersController.cs
@@ -1,0 +1,18 @@
+namespace Hackathon.Controllers;
+
+using Hackathon.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize(Policy = "AdminOrAnalyst")]
+public class UsersController(IUserService userService) : ControllerBase
+{
+    [HttpGet("latest-scan")]
+    public async Task<IActionResult> GetUsersWithLatestScan()
+    {
+        var users = await userService.GetUsersWithLastScanAsync();
+        return Ok(users);
+    }
+}

--- a/Hackathon/Hackathon/Models/Dtos/UserScanSummaryResponse.cs
+++ b/Hackathon/Hackathon/Models/Dtos/UserScanSummaryResponse.cs
@@ -1,0 +1,9 @@
+namespace Hackathon.Models.Dtos;
+
+public class UserScanSummaryResponse
+{
+    public long Id { get; set; }
+    public string Email { get; set; } = null!;
+    public string? FullName { get; set; }
+    public DateTime? LastScannedAt { get; set; }
+}

--- a/Hackathon/Hackathon/Program.cs
+++ b/Hackathon/Hackathon/Program.cs
@@ -57,6 +57,7 @@ builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<IIsoDocumentService, IsoDocumentService>();
 builder.Services.AddScoped<IApprovedApplicationService, ApprovedApplicationService>();
 builder.Services.AddScoped<IDeviceScanService, DeviceScanService>();
+builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddMinio(config =>
 {
     config.WithEndpoint(builder.Configuration["Minio:Endpoint"]!)

--- a/Hackathon/Hackathon/Repositories/IUserRepository.cs
+++ b/Hackathon/Hackathon/Repositories/IUserRepository.cs
@@ -1,11 +1,13 @@
 namespace Hackathon.Repositories;
 
 using Hackathon.Models;
+using Hackathon.Models.Dtos;
 
 public interface IUserRepository
 {
     Task<User?> GetByEmailAsync(string email);
     Task AddAsync(User user);
     void Update(User user);
+    Task<IEnumerable<UserScanSummaryResponse>> GetUsersWithLastScanAsync();
 }
 

--- a/Hackathon/Hackathon/Repositories/UserRepository.cs
+++ b/Hackathon/Hackathon/Repositories/UserRepository.cs
@@ -1,6 +1,7 @@
 namespace Hackathon.Repositories;
 
 using Hackathon.Models;
+using Hackathon.Models.Dtos;
 using Hackathon.UnitOfWork;
 using Microsoft.EntityFrameworkCore;
 
@@ -17,5 +18,22 @@ public class UserRepository(AppDbContext context) : IUserRepository
     public async Task AddAsync(User user) => await context.Users.AddAsync(user);
 
     public void Update(User user) => context.Users.Update(user);
+
+    public async Task<IEnumerable<UserScanSummaryResponse>> GetUsersWithLastScanAsync()
+    {
+        return await context.Users
+            .Select(u => new UserScanSummaryResponse
+            {
+                Id = u.Id,
+                Email = u.Email,
+                FullName = u.FullName,
+                LastScannedAt = context.DeviceScans
+                    .Where(ds => ds.UserId == u.Id)
+                    .OrderByDescending(ds => ds.ScannedAt)
+                    .Select(ds => (DateTime?)ds.ScannedAt)
+                    .FirstOrDefault()
+            })
+            .ToListAsync();
+    }
 }
 

--- a/Hackathon/Hackathon/Services/IUserService.cs
+++ b/Hackathon/Hackathon/Services/IUserService.cs
@@ -1,0 +1,10 @@
+namespace Hackathon.Services;
+
+using Hackathon.Models.Dtos;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public interface IUserService
+{
+    Task<IEnumerable<UserScanSummaryResponse>> GetUsersWithLastScanAsync();
+}

--- a/Hackathon/Hackathon/Services/UserService.cs
+++ b/Hackathon/Hackathon/Services/UserService.cs
@@ -1,0 +1,14 @@
+namespace Hackathon.Services;
+
+using Hackathon.Models.Dtos;
+using Hackathon.UnitOfWork;
+
+public class UserService(IUnitOfWork unitOfWork) : IUserService
+{
+    private readonly IUnitOfWork _unitOfWork = unitOfWork;
+
+    public async Task<IEnumerable<UserScanSummaryResponse>> GetUsersWithLastScanAsync()
+    {
+        return await _unitOfWork.Users.GetUsersWithLastScanAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- implement UsersController with admin or analyst authorization to list users with their last device scan
- add UserService and repository method to fetch latest device scan timestamp
- register new service in application startup
- refactor repository query to use a DeviceScans subquery for latest scan retrieval

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bd52613c248331ab7f9bfc511a988c