### PR TITLE
Rename user components to manager

### DIFF
--- a/Hackathon/Hackathon/Controllers/ManagerUserController.cs
+++ b/Hackathon/Hackathon/Controllers/ManagerUserController.cs
@@ -7,12 +7,12 @@ using Microsoft.AspNetCore.Mvc;
 [ApiController]
 [Route("api/[controller]")]
 [Authorize(Policy = "AdminOrAnalyst")]
-public class UsersController(IUserService userService) : ControllerBase
+public class ManagerUserController(IManagerUserService managerUserService) : ControllerBase
 {
     [HttpGet("latest-scan")]
     public async Task<IActionResult> GetUsersWithLatestScan()
     {
-        var users = await userService.GetUsersWithLastScanAsync();
+        var users = await managerUserService.GetUsersWithLastScanAsync();
         return Ok(users);
     }
 }

--- a/Hackathon/Hackathon/Program.cs
+++ b/Hackathon/Hackathon/Program.cs
@@ -57,7 +57,7 @@ builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<IIsoDocumentService, IsoDocumentService>();
 builder.Services.AddScoped<IApprovedApplicationService, ApprovedApplicationService>();
 builder.Services.AddScoped<IDeviceScanService, DeviceScanService>();
-builder.Services.AddScoped<IUserService, UserService>();
+builder.Services.AddScoped<IManagerUserService, ManagerUserService>();
 builder.Services.AddMinio(config =>
 {
     config.WithEndpoint(builder.Configuration["Minio:Endpoint"]!)

--- a/Hackathon/Hackathon/Services/IManagerUserService.cs
+++ b/Hackathon/Hackathon/Services/IManagerUserService.cs
@@ -4,7 +4,7 @@ using Hackathon.Models.Dtos;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-public interface IUserService
+public interface IManagerUserService
 {
     Task<IEnumerable<UserScanSummaryResponse>> GetUsersWithLastScanAsync();
 }

--- a/Hackathon/Hackathon/Services/ManagerUserService.cs
+++ b/Hackathon/Hackathon/Services/ManagerUserService.cs
@@ -3,7 +3,7 @@ namespace Hackathon.Services;
 using Hackathon.Models.Dtos;
 using Hackathon.UnitOfWork;
 
-public class UserService(IUnitOfWork unitOfWork) : IUserService
+public class ManagerUserService(IUnitOfWork unitOfWork) : IManagerUserService
 {
     private readonly IUnitOfWork _unitOfWork = unitOfWork;
 


### PR DESCRIPTION
## Summary
- rename UsersController to ManagerUserController
- rename UserService to ManagerUserService and update interface
- update dependency injection registration for manager user service

## Testing
- `dotnet build Hackathon/Hackathon.sln` *(fails: bash: command not found: dotnet)*
- `apt-get update` *(fails: 403 Forbidden [IP: 172.30.0.99 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68bd5743a7b88331844b6f1074fa3466