### PR TITLE
Add scan history API and whitelist approval logic

### DIFF
--- a/Hackathon/Hackathon/Controllers/ManagerUserController.cs
+++ b/Hackathon/Hackathon/Controllers/ManagerUserController.cs
@@ -29,4 +29,20 @@ public class ManagerUserController(IManagerUserService managerUserService) : Con
         var users = await managerUserService.GetUsersWithLastScanAsync();
         return Ok(users);
     }
+
+    /// <summary>
+    /// Retrieves scan history for a specific user.
+    /// </summary>
+    /// <param name="userId">Identifier of the user.</param>
+    /// <returns>Scan history and latest scan details.</returns>
+    [HttpGet("{userId:long}/scan-history")]
+    [SwaggerOperation(Summary = "Retrieves scan history for a user.", Description = "Gets device scan history and latest scan details for the specified user.")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(UserScanHistoryResponse))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetUserScanHistory(long userId)
+    {
+        var history = await managerUserService.GetUserScanHistoryAsync(userId);
+        return Ok(history);
+    }
 }

--- a/Hackathon/Hackathon/Models/Dtos/DeviceScanHistoryItemResponse.cs
+++ b/Hackathon/Hackathon/Models/Dtos/DeviceScanHistoryItemResponse.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Hackathon.Models.Dtos;
+
+public class DeviceScanHistoryItemResponse
+{
+    public long Id { get; set; }
+    public DateTime ScannedAt { get; set; }
+    public int ApplicationCount { get; set; }
+}

--- a/Hackathon/Hackathon/Models/Dtos/UserScanHistoryResponse.cs
+++ b/Hackathon/Hackathon/Models/Dtos/UserScanHistoryResponse.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace Hackathon.Models.Dtos;
+
+public class UserScanHistoryResponse
+{
+    public List<DeviceScanHistoryItemResponse> History { get; set; } = new();
+    public string? LatestDeviceInfo { get; set; }
+    public List<ScannedApplicationResponse> LatestApplications { get; set; } = new();
+    public string? LatestStatus { get; set; }
+}

--- a/Hackathon/Hackathon/Services/DeviceScanService.cs
+++ b/Hackathon/Hackathon/Services/DeviceScanService.cs
@@ -33,12 +33,17 @@ public class DeviceScanService(IUnitOfWork unitOfWork) : IDeviceScanService
             .Select(a => a.AppName)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        // Collect scanned applications that are not in the whitelist
+        // Flag applications based on whitelist and collect violations
         var violations = new List<ScannedApplication>();
         foreach (var app in applications)
         {
-            if (!whitelistNames.Contains(app.AppName))
+            if (whitelistNames.Contains(app.AppName))
             {
+                app.IsApproved = true;
+            }
+            else
+            {
+                app.IsApproved = false;
                 violations.Add(app);
             }
         }

--- a/Hackathon/Hackathon/Services/IManagerUserService.cs
+++ b/Hackathon/Hackathon/Services/IManagerUserService.cs
@@ -7,4 +7,5 @@ using System.Threading.Tasks;
 public interface IManagerUserService
 {
     Task<IEnumerable<UserScanSummaryResponse>> GetUsersWithLastScanAsync();
+    Task<UserScanHistoryResponse> GetUserScanHistoryAsync(long userId);
 }

--- a/Hackathon/Hackathon/Services/ManagerUserService.cs
+++ b/Hackathon/Hackathon/Services/ManagerUserService.cs
@@ -2,6 +2,8 @@ namespace Hackathon.Services;
 
 using Hackathon.Models.Dtos;
 using Hackathon.UnitOfWork;
+using System.Linq;
+using System.Collections.Generic;
 
 public class ManagerUserService(IUnitOfWork unitOfWork) : IManagerUserService
 {
@@ -10,5 +12,36 @@ public class ManagerUserService(IUnitOfWork unitOfWork) : IManagerUserService
     public async Task<IEnumerable<UserScanSummaryResponse>> GetUsersWithLastScanAsync()
     {
         return await _unitOfWork.Users.GetUsersWithLastScanAsync();
+    }
+
+    public async Task<UserScanHistoryResponse> GetUserScanHistoryAsync(long userId)
+    {
+        var scans = await _unitOfWork.DeviceScans.GetByUserIdAsync(userId);
+        var ordered = scans.OrderByDescending(s => s.ScannedAt).ToList();
+
+        var history = ordered.Select(s => new DeviceScanHistoryItemResponse
+        {
+            Id = s.Id,
+            ScannedAt = s.ScannedAt,
+            ApplicationCount = s.ScannedApplications.Count
+        }).ToList();
+
+        var latest = ordered.FirstOrDefault();
+
+        return new UserScanHistoryResponse
+        {
+            History = history,
+            LatestDeviceInfo = latest?.DeviceInfo,
+            LatestApplications = latest?.ScannedApplications.Select(a => new ScannedApplicationResponse
+            {
+                Id = a.Id,
+                AppName = a.AppName,
+                AppVersion = a.AppVersion,
+                Vendor = a.Vendor,
+                IsApproved = a.IsApproved,
+                CheckedAt = a.CheckedAt
+            }).ToList() ?? new List<ScannedApplicationResponse>(),
+            LatestStatus = latest?.Violations.FirstOrDefault()?.Status
+        };
     }
 }


### PR DESCRIPTION
## Summary
- add manager endpoint to fetch user scan history with latest details
- set scanned application approval flag during scan
- introduce DTOs for scan history summaries

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd63faf7488331b824cfb6c0bb2842