### PR TITLE
feat: add approved scan counts

### DIFF
--- a/Hackathon/Hackathon/Models/Dtos/DeviceScanHistoryItemResponse.cs
+++ b/Hackathon/Hackathon/Models/Dtos/DeviceScanHistoryItemResponse.cs
@@ -7,4 +7,5 @@ public class DeviceScanHistoryItemResponse
     public long Id { get; set; }
     public DateTime ScannedAt { get; set; }
     public int ApplicationCount { get; set; }
+    public int ApprovedApplicationCount { get; set; }
 }

--- a/Hackathon/Hackathon/Models/Dtos/UserScanSummaryResponse.cs
+++ b/Hackathon/Hackathon/Models/Dtos/UserScanSummaryResponse.cs
@@ -6,4 +6,5 @@ public class UserScanSummaryResponse
     public string Email { get; set; } = null!;
     public string? FullName { get; set; }
     public DateTime? LastScannedAt { get; set; }
+    public int ApprovedApplicationCount { get; set; }
 }

--- a/Hackathon/Hackathon/Repositories/UserRepository.cs
+++ b/Hackathon/Hackathon/Repositories/UserRepository.cs
@@ -4,6 +4,7 @@ using Hackathon.Models;
 using Hackathon.Models.Dtos;
 using Hackathon.UnitOfWork;
 using Microsoft.EntityFrameworkCore;
+using System.Linq;
 
 public class UserRepository(AppDbContext context) : IUserRepository
 {
@@ -31,6 +32,11 @@ public class UserRepository(AppDbContext context) : IUserRepository
                     .Where(ds => ds.UserId == u.Id)
                     .OrderByDescending(ds => ds.ScannedAt)
                     .Select(ds => (DateTime?)ds.ScannedAt)
+                    .FirstOrDefault(),
+                ApprovedApplicationCount = context.DeviceScans
+                    .Where(ds => ds.UserId == u.Id)
+                    .OrderByDescending(ds => ds.ScannedAt)
+                    .Select(ds => ds.ScannedApplications.Count(sa => sa.IsApproved == true))
                     .FirstOrDefault()
             })
             .ToListAsync();

--- a/Hackathon/Hackathon/Services/ManagerUserService.cs
+++ b/Hackathon/Hackathon/Services/ManagerUserService.cs
@@ -23,7 +23,8 @@ public class ManagerUserService(IUnitOfWork unitOfWork) : IManagerUserService
         {
             Id = s.Id,
             ScannedAt = s.ScannedAt,
-            ApplicationCount = s.ScannedApplications.Count
+            ApplicationCount = s.ScannedApplications.Count,
+            ApprovedApplicationCount = s.ScannedApplications.Count(a => a.IsApproved == true)
         }).ToList();
 
         var latest = ordered.FirstOrDefault();


### PR DESCRIPTION
## Summary
- include count of approved applications in user summary
- expose number of approved apps per scan in history

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bda204233c833185de127e66635c7e