### PR TITLE
Add manager stats endpoint

### DIFF
--- a/Hackathon/Hackathon/Controllers/ManagerUserController.cs
+++ b/Hackathon/Hackathon/Controllers/ManagerUserController.cs
@@ -45,4 +45,19 @@ public class ManagerUserController(IManagerUserService managerUserService) : Con
         var history = await managerUserService.GetUserScanHistoryAsync(userId);
         return Ok(history);
     }
+
+    /// <summary>
+    /// Retrieves user statistics.
+    /// </summary>
+    /// <returns>Total user count and count of users whose latest scans contain violations.</returns>
+    [HttpGet("stats")]
+    [SwaggerOperation(Summary = "Retrieves user statistics.", Description = "Gets total number of users and number of users with violations in their latest scan.")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ManagerStatsResponse))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetStats()
+    {
+        var stats = await managerUserService.GetStatsAsync();
+        return Ok(stats);
+    }
 }

--- a/Hackathon/Hackathon/Models/Dtos/ManagerStatsResponse.cs
+++ b/Hackathon/Hackathon/Models/Dtos/ManagerStatsResponse.cs
@@ -1,0 +1,7 @@
+namespace Hackathon.Models.Dtos;
+
+public class ManagerStatsResponse
+{
+    public int TotalUsers { get; set; }
+    public int UsersWithViolations { get; set; }
+}

--- a/Hackathon/Hackathon/Repositories/IUserRepository.cs
+++ b/Hackathon/Hackathon/Repositories/IUserRepository.cs
@@ -9,5 +9,7 @@ public interface IUserRepository
     Task AddAsync(User user);
     void Update(User user);
     Task<IEnumerable<UserScanSummaryResponse>> GetUsersWithLastScanAsync();
+    Task<int> CountAsync();
+    Task<int> CountUsersWithLatestScanViolationAsync();
 }
 

--- a/Hackathon/Hackathon/Repositories/UserRepository.cs
+++ b/Hackathon/Hackathon/Repositories/UserRepository.cs
@@ -41,5 +41,18 @@ public class UserRepository(AppDbContext context) : IUserRepository
             })
             .ToListAsync();
     }
+
+    public async Task<int> CountAsync() => await context.Users.CountAsync();
+
+    public async Task<int> CountUsersWithLatestScanViolationAsync()
+    {
+        return await context.Users
+            .Where(u => context.DeviceScans
+                .Where(ds => ds.UserId == u.Id)
+                .OrderByDescending(ds => ds.ScannedAt)
+                .Take(1)
+                .Any(ds => ds.Violations.Any()))
+            .CountAsync();
+    }
 }
 

--- a/Hackathon/Hackathon/Services/IManagerUserService.cs
+++ b/Hackathon/Hackathon/Services/IManagerUserService.cs
@@ -8,4 +8,5 @@ public interface IManagerUserService
 {
     Task<IEnumerable<UserScanSummaryResponse>> GetUsersWithLastScanAsync();
     Task<UserScanHistoryResponse> GetUserScanHistoryAsync(long userId);
+    Task<ManagerStatsResponse> GetStatsAsync();
 }

--- a/Hackathon/Hackathon/Services/ManagerUserService.cs
+++ b/Hackathon/Hackathon/Services/ManagerUserService.cs
@@ -45,4 +45,16 @@ public class ManagerUserService(IUnitOfWork unitOfWork) : IManagerUserService
             LatestStatus = latest?.Violations.FirstOrDefault()?.Status
         };
     }
+
+    public async Task<ManagerStatsResponse> GetStatsAsync()
+    {
+        var totalUsers = await _unitOfWork.Users.CountAsync();
+        var violationUsers = await _unitOfWork.Users.CountUsersWithLatestScanViolationAsync();
+
+        return new ManagerStatsResponse
+        {
+            TotalUsers = totalUsers,
+            UsersWithViolations = violationUsers
+        };
+    }
 }


### PR DESCRIPTION
## Summary
- handle user statistics in existing manager user service instead of a separate service
- expose `GET /api/manageruser/stats` returning total users and users with latest scan violations
- register only `ManagerUserService` for manager operations

## Testing
- `dotnet build Hackathon/Hackathon.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bda7f5155883318dce1d973fdee291