### PR TITLE
Add endpoint to reset ISO document scan time

### DIFF
--- a/Hackathon/Hackathon/Controllers/IsoDocumentsController.cs
+++ b/Hackathon/Hackathon/Controllers/IsoDocumentsController.cs
@@ -167,6 +167,25 @@ public class IsoDocumentsController : ControllerBase
     }
 
     /// <summary>
+    /// Resets the scan time of an ISO document.
+    /// </summary>
+    [HttpPost("{id:long}/reset-scan")]
+    [SwaggerOperation(Summary = "Resets scan time of an ISO document.", Description = "Sets the scanned timestamp of the specified ISO document to null.")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> ResetScan(long id)
+    {
+        var success = await _service.ResetScanAsync(id);
+        if (!success)
+        {
+            return NotFound();
+        }
+        return NoContent();
+    }
+
+    /// <summary>
     /// Uploads files to an existing ISO document.
     /// </summary>
     [HttpPost("{id:long}/upload")]

--- a/Hackathon/Hackathon/Services/IIsoDocumentService.cs
+++ b/Hackathon/Hackathon/Services/IIsoDocumentService.cs
@@ -11,6 +11,7 @@ public interface IIsoDocumentService
     Task<bool> UpdateAsync(long id, IsoDocumentRequest request);
     Task<bool> DeleteAsync(long id);
     Task<bool> EnableAsync(long id);
+    Task<bool> ResetScanAsync(long id);
     Task<IsoDocument> UploadAsync(long documentId, UploadIsoDocumentRequest request, long uploaderId);
     Task<IEnumerable<IsoDocument>> GetByYearAsync(int year);
     Task<IEnumerable<IsoFile>?> GetFilesAsync(long documentId);

--- a/Hackathon/Hackathon/Services/IsoDocumentService.cs
+++ b/Hackathon/Hackathon/Services/IsoDocumentService.cs
@@ -76,6 +76,18 @@ public class IsoDocumentService(IUnitOfWork unitOfWork, IFileService fileService
         return true;
     }
 
+    public async Task<bool> ResetScanAsync(long id)
+    {
+        var document = await _unitOfWork.IsoDocuments.GetByIdAsync(id);
+        if (document == null)
+        {
+            return false;
+        }
+        document.ScannedAt = null;
+        await _unitOfWork.SaveChangesAsync();
+        return true;
+    }
+
     public async Task<IsoDocument> UploadAsync(long documentId, UploadIsoDocumentRequest request, long uploaderId)
     {
         if (request.Files.Sum(f => f.Length) > MaxRequestSize)


### PR DESCRIPTION
## Summary
- add ResetScan endpoint in IsoDocuments controller
- implement service method to clear scanned timestamp

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdadf9a6408331b2ea2b3cc8b040b8