### PR TITLE
Use presigned URLs for ISO document files

### DIFF
--- a/Hackathon/Hackathon/Controllers/IsoDocumentsController.cs
+++ b/Hackathon/Hackathon/Controllers/IsoDocumentsController.cs
@@ -16,11 +16,14 @@ namespace Hackathon.Controllers;
 [Authorize(Policy = "AdminOrAnalyst")]
 public class IsoDocumentsController : ControllerBase
 {
+    private const int SevenDaysInSeconds = 60 * 60 * 24 * 7;
     private readonly IIsoDocumentService _service;
+    private readonly IFileService _fileService;
 
-    public IsoDocumentsController(IIsoDocumentService service)
+    public IsoDocumentsController(IIsoDocumentService service, IFileService fileService)
     {
         _service = service;
+        _fileService = fileService;
     }
 
     /// <summary>
@@ -34,6 +37,13 @@ public class IsoDocumentsController : ControllerBase
     public async Task<IActionResult> GetAll()
     {
         var docs = await _service.GetAllAsync();
+        foreach (var doc in docs)
+        {
+            foreach (var file in doc.Files)
+            {
+                file.FilePath = await _fileService.GetPresignedUrlAsync(file.FilePath, SevenDaysInSeconds);
+            }
+        }
         return Ok(docs);
     }
 
@@ -53,6 +63,10 @@ public class IsoDocumentsController : ControllerBase
         {
             return NotFound();
         }
+        foreach (var file in doc.Files)
+        {
+            file.FilePath = await _fileService.GetPresignedUrlAsync(file.FilePath, SevenDaysInSeconds);
+        }
         return Ok(doc);
     }
 
@@ -67,6 +81,13 @@ public class IsoDocumentsController : ControllerBase
     public async Task<IActionResult> GetByYear(int year)
     {
         var documents = await _service.GetByYearAsync(year);
+        foreach (var doc in documents)
+        {
+            foreach (var file in doc.Files)
+            {
+                file.FilePath = await _fileService.GetPresignedUrlAsync(file.FilePath, SevenDaysInSeconds);
+            }
+        }
         return Ok(documents);
     }
 
@@ -85,6 +106,10 @@ public class IsoDocumentsController : ControllerBase
         if (files == null)
         {
             return NotFound();
+        }
+        foreach (var file in files)
+        {
+            file.FilePath = await _fileService.GetPresignedUrlAsync(file.FilePath, SevenDaysInSeconds);
         }
         return Ok(files);
     }

--- a/Hackathon/Hackathon/Services/FileService.cs
+++ b/Hackathon/Hackathon/Services/FileService.cs
@@ -34,6 +34,15 @@ public class FileService(IMinioClient client, IConfiguration configuration) : IF
             .WithObject(objectName));
     }
 
+    public async Task<string> GetPresignedUrlAsync(string fileUrl, int expiryInSeconds)
+    {
+        var objectName = fileUrl.Split('/', StringSplitOptions.RemoveEmptyEntries).Last();
+        return await _client.PresignedGetObjectAsync(new PresignedGetObjectArgs()
+            .WithBucket(_bucketName)
+            .WithObject(objectName)
+            .WithExpiry(expiryInSeconds));
+    }
+
     private async Task EnsureBucketExistsAsync()
     {
         var bucketExists = await _client.BucketExistsAsync(new BucketExistsArgs().WithBucket(_bucketName));

--- a/Hackathon/Hackathon/Services/IFileService.cs
+++ b/Hackathon/Hackathon/Services/IFileService.cs
@@ -6,4 +6,5 @@ public interface IFileService
 {
     Task<string> UploadFileAsync(IFormFile file);
     Task DeleteFileAsync(string fileUrl);
+    Task<string> GetPresignedUrlAsync(string fileUrl, int expiryInSeconds);
 }


### PR DESCRIPTION
## Summary
- Inject `IFileService` into `IsoDocumentsController` and transform ISO file paths into 7-day presigned URLs for all GET endpoints
- Extend `IFileService` and implement `GetPresignedUrlAsync` in `FileService`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bdba8248008331a94838cd63c0842e