### PR TITLE
Include total application count in last user scan summary

### DIFF
--- a/Hackathon/Hackathon/Models/Dtos/UserScanSummaryResponse.cs
+++ b/Hackathon/Hackathon/Models/Dtos/UserScanSummaryResponse.cs
@@ -7,4 +7,5 @@ public class UserScanSummaryResponse
     public string? FullName { get; set; }
     public DateTime? LastScannedAt { get; set; }
     public int ApprovedApplicationCount { get; set; }
+    public int TotalApplicationCount { get; set; }
 }

--- a/Hackathon/Hackathon/Repositories/UserRepository.cs
+++ b/Hackathon/Hackathon/Repositories/UserRepository.cs
@@ -37,6 +37,11 @@ public class UserRepository(AppDbContext context) : IUserRepository
                     .Where(ds => ds.UserId == u.Id)
                     .OrderByDescending(ds => ds.ScannedAt)
                     .Select(ds => ds.ScannedApplications.Count(sa => sa.IsApproved == true))
+                    .FirstOrDefault(),
+                TotalApplicationCount = context.DeviceScans
+                    .Where(ds => ds.UserId == u.Id)
+                    .OrderByDescending(ds => ds.ScannedAt)
+                    .Select(ds => ds.ScannedApplications.Count())
                     .FirstOrDefault()
             })
             .ToListAsync();


### PR DESCRIPTION
## Summary
- Track total applications scanned in last scan via `TotalApplicationCount`
- Return the total count from `GetUsersWithLastScanAsync`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbd65e5888331b04be7d71460b182